### PR TITLE
feat: Sync new CPU Definitions (AMD 1Ah) and Configuration Headers from Acidanthera

### DIFF
--- a/Include/Acidanthera/Library/OcConfigurationLib.h
+++ b/Include/Acidanthera/Library/OcConfigurationLib.h
@@ -4,9 +4,9 @@
   All rights reserved.
 
   This program and the accompanying materials
-  are licensed and made available under the terms and conditions of the BSD License
-  which accompanies this distribution.  The full text of the license may be found at
-  http://opensource.org/licenses/bsd-license.php
+  are licensed and made available under the terms and conditions of the BSD
+License which accompanies this distribution.  The full text of the license may
+be found at http://opensource.org/licenses/bsd-license.php
 
   THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
   WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
@@ -16,8 +16,8 @@
 #define OC_CONFIGURATION_LIB_H
 
 #include <Library/DebugLib.h>
-#include <Library/OcSerializeLib.h>
 #include <Library/OcBootManagementLib.h>
+#include <Library/OcSerializeLib.h>
 
 /**
   ACPI section
@@ -26,169 +26,175 @@
 ///
 /// ACPI added tables.
 ///
-#define OC_ACPI_ADD_ENTRY_FIELDS(_, __) \
-  _(BOOLEAN                     , Enabled          ,     , FALSE   , () ) \
-  _(OC_STRING                   , Comment          ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , Path             ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING) )
-OC_DECLARE (OC_ACPI_ADD_ENTRY)
+#define OC_ACPI_ADD_ENTRY_FIELDS(_, __)                                        \
+  _(BOOLEAN, Enabled, , FALSE, ())                                             \
+  _(OC_STRING, Comment, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))    \
+  _(OC_STRING, Path, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))
+OC_DECLARE(OC_ACPI_ADD_ENTRY)
 
-#define OC_ACPI_ADD_ARRAY_FIELDS(_, __) \
-  OC_ARRAY (OC_ACPI_ADD_ENTRY, _, __)
-OC_DECLARE (OC_ACPI_ADD_ARRAY)
+#define OC_ACPI_ADD_ARRAY_FIELDS(_, __) OC_ARRAY(OC_ACPI_ADD_ENTRY, _, __)
+OC_DECLARE(OC_ACPI_ADD_ARRAY)
 
 ///
 /// ACPI table deletion.
 ///
-#define OC_ACPI_DELETE_ENTRY_FIELDS(_, __) \
-  _(BOOLEAN                     , All              ,     , FALSE   , () ) \
-  _(BOOLEAN                     , Enabled          ,     , FALSE   , () ) \
-  _(OC_STRING                   , Comment          ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING) ) \
-  _(UINT8                       , OemTableId       , [8] , {0}     , () ) \
-  _(UINT32                      , TableLength      ,     , 0       , () ) \
-  _(UINT8                       , TableSignature   , [4] , {0}     , () )
-OC_DECLARE (OC_ACPI_DELETE_ENTRY)
+#define OC_ACPI_DELETE_ENTRY_FIELDS(_, __)                                     \
+  _(BOOLEAN, All, , FALSE, ())                                                 \
+  _(BOOLEAN, Enabled, , FALSE, ())                                             \
+  _(OC_STRING, Comment, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))    \
+  _(UINT8, OemTableId, [8], {0}, ())                                           \
+  _(UINT32, TableLength, , 0, ())                                              \
+  _(UINT8, TableSignature, [4], {0}, ())
+OC_DECLARE(OC_ACPI_DELETE_ENTRY)
 
-#define OC_ACPI_DELETE_ARRAY_FIELDS(_, __) \
-  OC_ARRAY (OC_ACPI_DELETE_ENTRY, _, __)
-OC_DECLARE (OC_ACPI_DELETE_ARRAY)
+#define OC_ACPI_DELETE_ARRAY_FIELDS(_, __) OC_ARRAY(OC_ACPI_DELETE_ENTRY, _, __)
+OC_DECLARE(OC_ACPI_DELETE_ARRAY)
 
 ///
 /// ACPI patches.
 ///
-#define OC_ACPI_PATCH_ENTRY_FIELDS(_, __) \
-  _(UINT32                      , Count            ,     , 0                           , ()                   ) \
-  _(BOOLEAN                     , Enabled          ,     , FALSE                       , ()                   ) \
-  _(OC_STRING                   , Comment          ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING) ) \
-  _(OC_DATA                     , Find             ,     , OC_EDATA_CONSTR (_, __)     , OC_DESTR (OC_DATA)   ) \
-  _(OC_STRING                   , Base             ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING) ) \
-  _(UINT32                      , BaseSkip         ,     , 0                           , ()                   ) \
-  _(UINT32                      , Limit            ,     , 0                           , ()                   ) \
-  _(OC_DATA                     , Mask             ,     , OC_EDATA_CONSTR (_, __)     , OC_DESTR (OC_DATA)   ) \
-  _(OC_DATA                     , Replace          ,     , OC_EDATA_CONSTR (_, __)     , OC_DESTR (OC_DATA)   ) \
-  _(OC_DATA                     , ReplaceMask      ,     , OC_EDATA_CONSTR (_, __)     , OC_DESTR (OC_DATA)   ) \
-  _(UINT8                       , OemTableId       , [8] , {0}                         , ()                   ) \
-  _(UINT32                      , TableLength      ,     , 0                           , ()                   ) \
-  _(UINT8                       , TableSignature   , [4] , {0}                         , ()                   ) \
-  _(UINT32                      , Skip             ,     , 0                           , ()                   )
-OC_DECLARE (OC_ACPI_PATCH_ENTRY)
+#define OC_ACPI_PATCH_ENTRY_FIELDS(_, __)                                      \
+  _(UINT32, Count, , 0, ())                                                    \
+  _(BOOLEAN, Enabled, , FALSE, ())                                             \
+  _(OC_STRING, Comment, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))    \
+  _(OC_DATA, Find, , OC_EDATA_CONSTR(_, __), OC_DESTR(OC_DATA))                \
+  _(OC_STRING, Base, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))       \
+  _(UINT32, BaseSkip, , 0, ())                                                 \
+  _(UINT32, Limit, , 0, ())                                                    \
+  _(OC_DATA, Mask, , OC_EDATA_CONSTR(_, __), OC_DESTR(OC_DATA))                \
+  _(OC_DATA, Replace, , OC_EDATA_CONSTR(_, __), OC_DESTR(OC_DATA))             \
+  _(OC_DATA, ReplaceMask, , OC_EDATA_CONSTR(_, __), OC_DESTR(OC_DATA))         \
+  _(UINT8, OemTableId, [8], {0}, ())                                           \
+  _(UINT32, TableLength, , 0, ())                                              \
+  _(UINT8, TableSignature, [4], {0}, ())                                       \
+  _(UINT32, Skip, , 0, ())
+OC_DECLARE(OC_ACPI_PATCH_ENTRY)
 
-#define OC_ACPI_PATCH_ARRAY_FIELDS(_, __) \
-  OC_ARRAY (OC_ACPI_PATCH_ENTRY, _, __)
-OC_DECLARE (OC_ACPI_PATCH_ARRAY)
+#define OC_ACPI_PATCH_ARRAY_FIELDS(_, __) OC_ARRAY(OC_ACPI_PATCH_ENTRY, _, __)
+OC_DECLARE(OC_ACPI_PATCH_ARRAY)
 
 ///
 /// ACPI quirks.
 ///
-#define OC_ACPI_QUIRKS_FIELDS(_, __) \
-  _(BOOLEAN                     , FadtEnableReset     ,     , FALSE  , ()) \
-  _(BOOLEAN                     , NormalizeHeaders    ,     , FALSE  , ()) \
-  _(BOOLEAN                     , RebaseRegions       ,     , FALSE  , ()) \
-  _(BOOLEAN                     , ResetHwSig          ,     , FALSE  , ()) \
-  _(BOOLEAN                     , ResetLogoStatus     ,     , FALSE  , ()) \
-  _(BOOLEAN                     , SyncTableIds        ,     , FALSE  , ())
-OC_DECLARE (OC_ACPI_QUIRKS)
+#define OC_ACPI_QUIRKS_FIELDS(_, __)                                           \
+  _(BOOLEAN, FadtEnableReset, , FALSE, ())                                     \
+  _(BOOLEAN, NormalizeHeaders, , FALSE, ())                                    \
+  _(BOOLEAN, RebaseRegions, , FALSE, ())                                       \
+  _(BOOLEAN, ResetHwSig, , FALSE, ())                                          \
+  _(BOOLEAN, ResetLogoStatus, , FALSE, ())                                     \
+  _(BOOLEAN, SyncTableIds, , FALSE, ())
+OC_DECLARE(OC_ACPI_QUIRKS)
 
-#define OC_ACPI_CONFIG_FIELDS(_, __) \
-  _(OC_ACPI_ADD_ARRAY         , Add              ,     , OC_CONSTR2 (OC_ACPI_ADD_ARRAY, _, __)     , OC_DESTR (OC_ACPI_ADD_ARRAY)) \
-  _(OC_ACPI_DELETE_ARRAY      , Delete           ,     , OC_CONSTR2 (OC_ACPI_DELETE_ARRAY, _, __)  , OC_DESTR (OC_ACPI_DELETE_ARRAY)) \
-  _(OC_ACPI_PATCH_ARRAY       , Patch            ,     , OC_CONSTR2 (OC_ACPI_PATCH_ARRAY, _, __)   , OC_DESTR (OC_ACPI_PATCH_ARRAY)) \
-  _(OC_ACPI_QUIRKS            , Quirks           ,     , OC_CONSTR2 (OC_ACPI_QUIRKS, _, __)        , OC_DESTR (OC_ACPI_QUIRKS))
-OC_DECLARE (OC_ACPI_CONFIG)
+#define OC_ACPI_CONFIG_FIELDS(_, __)                                           \
+  _(OC_ACPI_ADD_ARRAY, Add, , OC_CONSTR2(OC_ACPI_ADD_ARRAY, _, __),            \
+    OC_DESTR(OC_ACPI_ADD_ARRAY))                                               \
+  _(OC_ACPI_DELETE_ARRAY, Delete, , OC_CONSTR2(OC_ACPI_DELETE_ARRAY, _, __),   \
+    OC_DESTR(OC_ACPI_DELETE_ARRAY))                                            \
+  _(OC_ACPI_PATCH_ARRAY, Patch, , OC_CONSTR2(OC_ACPI_PATCH_ARRAY, _, __),      \
+    OC_DESTR(OC_ACPI_PATCH_ARRAY))                                             \
+  _(OC_ACPI_QUIRKS, Quirks, , OC_CONSTR2(OC_ACPI_QUIRKS, _, __),               \
+    OC_DESTR(OC_ACPI_QUIRKS))
+OC_DECLARE(OC_ACPI_CONFIG)
 
 /**
   Apple bootloader section
 **/
 
-#define OC_BOOTER_WL_ENTRY_FIELDS(_, __) \
-  _(UINT64                      , Address          ,     , 0       , () ) \
-  _(BOOLEAN                     , Enabled          ,     , FALSE   , () ) \
-  _(OC_STRING                   , Comment          ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING) )
-OC_DECLARE (OC_BOOTER_WL_ENTRY)
+#define OC_BOOTER_WL_ENTRY_FIELDS(_, __)                                       \
+  _(UINT64, Address, , 0, ())                                                  \
+  _(BOOLEAN, Enabled, , FALSE, ())                                             \
+  _(OC_STRING, Comment, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))
+OC_DECLARE(OC_BOOTER_WL_ENTRY)
 
-#define OC_BOOTER_WL_ARRAY_FIELDS(_, __) \
-  OC_ARRAY (OC_BOOTER_WL_ENTRY, _, __)
-OC_DECLARE (OC_BOOTER_WL_ARRAY)
+#define OC_BOOTER_WL_ARRAY_FIELDS(_, __) OC_ARRAY(OC_BOOTER_WL_ENTRY, _, __)
+OC_DECLARE(OC_BOOTER_WL_ARRAY)
 
 ///
 /// Bootloader patches.
 ///
-#define OC_BOOTER_PATCH_ENTRY_FIELDS(_, __) \
-  _(OC_STRING                   , Arch             ,     , OC_STRING_CONSTR ("Any", _, __), OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , Comment          ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING) ) \
-  _(UINT32                      , Count            ,     , 0                           , ()                   ) \
-  _(BOOLEAN                     , Enabled          ,     , FALSE                       , ()                   ) \
-  _(OC_DATA                     , Find             ,     , OC_EDATA_CONSTR (_, __)     , OC_DESTR (OC_DATA)   ) \
-  _(OC_STRING                   , Identifier       ,     , OC_STRING_CONSTR ("Any", _, __), OC_DESTR (OC_STRING) ) \
-  _(OC_DATA                     , Mask             ,     , OC_EDATA_CONSTR (_, __)     , OC_DESTR (OC_DATA)   ) \
-  _(OC_DATA                     , Replace          ,     , OC_EDATA_CONSTR (_, __)     , OC_DESTR (OC_DATA)   ) \
-  _(OC_DATA                     , ReplaceMask      ,     , OC_EDATA_CONSTR (_, __)     , OC_DESTR (OC_DATA)   ) \
-  _(UINT32                      , Limit            ,     , 0                           , ()                   ) \
-  _(UINT32                      , Skip             ,     , 0                           , ()                   )
-OC_DECLARE (OC_BOOTER_PATCH_ENTRY)
+#define OC_BOOTER_PATCH_ENTRY_FIELDS(_, __)                                    \
+  _(OC_STRING, Arch, , OC_STRING_CONSTR("Any", _, __), OC_DESTR(OC_STRING))    \
+  _(OC_STRING, Comment, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))    \
+  _(UINT32, Count, , 0, ())                                                    \
+  _(BOOLEAN, Enabled, , FALSE, ())                                             \
+  _(OC_DATA, Find, , OC_EDATA_CONSTR(_, __), OC_DESTR(OC_DATA))                \
+  _(OC_STRING, Identifier, , OC_STRING_CONSTR("Any", _, __),                   \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_DATA, Mask, , OC_EDATA_CONSTR(_, __), OC_DESTR(OC_DATA))                \
+  _(OC_DATA, Replace, , OC_EDATA_CONSTR(_, __), OC_DESTR(OC_DATA))             \
+  _(OC_DATA, ReplaceMask, , OC_EDATA_CONSTR(_, __), OC_DESTR(OC_DATA))         \
+  _(UINT32, Limit, , 0, ())                                                    \
+  _(UINT32, Skip, , 0, ())
+OC_DECLARE(OC_BOOTER_PATCH_ENTRY)
 
-#define OC_BOOTER_PATCH_ARRAY_FIELDS(_, __) \
-  OC_ARRAY (OC_BOOTER_PATCH_ENTRY, _, __)
-OC_DECLARE (OC_BOOTER_PATCH_ARRAY)
+#define OC_BOOTER_PATCH_ARRAY_FIELDS(_, __)                                    \
+  OC_ARRAY(OC_BOOTER_PATCH_ENTRY, _, __)
+OC_DECLARE(OC_BOOTER_PATCH_ARRAY)
 
 ///
 /// Apple bootloader quirks.
 ///
-#define OC_BOOTER_QUIRKS_FIELDS(_, __) \
-  _(BOOLEAN                     , AllowRelocationBlock      ,     , FALSE  , ()) \
-  _(BOOLEAN                     , AvoidRuntimeDefrag        ,     , FALSE  , ()) \
-  _(BOOLEAN                     , DevirtualiseMmio          ,     , FALSE  , ()) \
-  _(BOOLEAN                     , DisableSingleUser         ,     , FALSE  , ()) \
-  _(BOOLEAN                     , DisableVariableWrite      ,     , FALSE  , ()) \
-  _(BOOLEAN                     , DiscardHibernateMap       ,     , FALSE  , ()) \
-  _(BOOLEAN                     , EnableSafeModeSlide       ,     , FALSE  , ()) \
-  _(BOOLEAN                     , EnableWriteUnprotector    ,     , FALSE  , ()) \
-  _(BOOLEAN                     , FixupAppleEfiImages       ,     , FALSE  , ()) \
-  _(BOOLEAN                     , ForceBooterSignature      ,     , FALSE  , ()) \
-  _(BOOLEAN                     , ForceExitBootServices     ,     , FALSE  , ()) \
-  _(BOOLEAN                     , ProtectMemoryRegions      ,     , FALSE  , ()) \
-  _(BOOLEAN                     , ProtectSecureBoot         ,     , FALSE  , ()) \
-  _(BOOLEAN                     , ProtectUefiServices       ,     , FALSE  , ()) \
-  _(BOOLEAN                     , ProvideCustomSlide        ,     , FALSE  , ()) \
-  _(UINT8                       , ProvideMaxSlide           ,     , 0      , ()) \
-  _(BOOLEAN                     , RebuildAppleMemoryMap     ,     , FALSE  , ()) \
-  _(INT8                        , ResizeAppleGpuBars        ,     , -1     , ()) \
-  _(BOOLEAN                     , SetupVirtualMap           ,     , FALSE  , ()) \
-  _(BOOLEAN                     , SignalAppleOS             ,     , FALSE  , ()) \
-  _(BOOLEAN                     , SyncRuntimePermissions    ,     , FALSE  , ())
-OC_DECLARE (OC_BOOTER_QUIRKS)
+#define OC_BOOTER_QUIRKS_FIELDS(_, __)                                         \
+  _(BOOLEAN, AllowRelocationBlock, , FALSE, ())                                \
+  _(BOOLEAN, AvoidRuntimeDefrag, , FALSE, ())                                  \
+  _(BOOLEAN, DevirtualiseMmio, , FALSE, ())                                    \
+  _(BOOLEAN, DisableSingleUser, , FALSE, ())                                   \
+  _(BOOLEAN, DisableVariableWrite, , FALSE, ())                                \
+  _(BOOLEAN, DiscardHibernateMap, , FALSE, ())                                 \
+  _(BOOLEAN, EnableSafeModeSlide, , FALSE, ())                                 \
+  _(BOOLEAN, EnableWriteUnprotector, , FALSE, ())                              \
+  _(BOOLEAN, FixupAppleEfiImages, , FALSE, ())                                 \
+  _(BOOLEAN, ForceBooterSignature, , FALSE, ())                                \
+  _(BOOLEAN, ForceExitBootServices, , FALSE, ())                               \
+  _(BOOLEAN, ProtectMemoryRegions, , FALSE, ())                                \
+  _(BOOLEAN, ProtectSecureBoot, , FALSE, ())                                   \
+  _(BOOLEAN, ProtectUefiServices, , FALSE, ())                                 \
+  _(BOOLEAN, ProvideCustomSlide, , FALSE, ())                                  \
+  _(UINT8, ProvideMaxSlide, , 0, ())                                           \
+  _(BOOLEAN, RebuildAppleMemoryMap, , FALSE, ())                               \
+  _(INT8, ResizeAppleGpuBars, , -1, ())                                        \
+  _(BOOLEAN, SetupVirtualMap, , FALSE, ())                                     \
+  _(BOOLEAN, SignalAppleOS, , FALSE, ())                                       \
+  _(BOOLEAN, SyncRuntimePermissions, , FALSE, ())
+OC_DECLARE(OC_BOOTER_QUIRKS)
 
 ///
 /// Apple bootloader section.
 ///
-#define OC_BOOTER_CONFIG_FIELDS(_, __) \
-  _(OC_BOOTER_WL_ARRAY          , MmioWhitelist    ,     , OC_CONSTR2 (OC_BOOTER_WL_ARRAY, _, __)      , OC_DESTR (OC_BOOTER_WL_ARRAY)) \
-  _(OC_BOOTER_PATCH_ARRAY       , Patch            ,     , OC_CONSTR2 (OC_BOOTER_PATCH_ARRAY, _, __)   , OC_DESTR (OC_BOOTER_PATCH_ARRAY)) \
-  _(OC_BOOTER_QUIRKS            , Quirks           ,     , OC_CONSTR2 (OC_BOOTER_QUIRKS, _, __)        , OC_DESTR (OC_BOOTER_QUIRKS))
-OC_DECLARE (OC_BOOTER_CONFIG)
+#define OC_BOOTER_CONFIG_FIELDS(_, __)                                         \
+  _(OC_BOOTER_WL_ARRAY, MmioWhitelist, ,                                       \
+    OC_CONSTR2(OC_BOOTER_WL_ARRAY, _, __), OC_DESTR(OC_BOOTER_WL_ARRAY))       \
+  _(OC_BOOTER_PATCH_ARRAY, Patch, , OC_CONSTR2(OC_BOOTER_PATCH_ARRAY, _, __),  \
+    OC_DESTR(OC_BOOTER_PATCH_ARRAY))                                           \
+  _(OC_BOOTER_QUIRKS, Quirks, , OC_CONSTR2(OC_BOOTER_QUIRKS, _, __),           \
+    OC_DESTR(OC_BOOTER_QUIRKS))
+OC_DECLARE(OC_BOOTER_CONFIG)
 
 /**
   DeviceProperties section
 **/
 
 ///
-/// Device properties is an associative map of devices with their property key value maps.
+/// Device properties is an associative map of devices with their property key
+/// value maps.
 ///
-#define OC_DEV_PROP_ADD_MAP_FIELDS(_, __) \
-  OC_MAP (OC_STRING, OC_ASSOC, _, __)
-OC_DECLARE (OC_DEV_PROP_ADD_MAP)
+#define OC_DEV_PROP_ADD_MAP_FIELDS(_, __) OC_MAP(OC_STRING, OC_ASSOC, _, __)
+OC_DECLARE(OC_DEV_PROP_ADD_MAP)
 
-#define OC_DEV_PROP_DELETE_ENTRY_FIELDS(_, __) \
-  OC_ARRAY (OC_STRING, _, __)
-OC_DECLARE (OC_DEV_PROP_DELETE_ENTRY)
+#define OC_DEV_PROP_DELETE_ENTRY_FIELDS(_, __) OC_ARRAY(OC_STRING, _, __)
+OC_DECLARE(OC_DEV_PROP_DELETE_ENTRY)
 
-#define OC_DEV_PROP_DELETE_MAP_FIELDS(_, __) \
-  OC_MAP (OC_STRING, OC_DEV_PROP_DELETE_ENTRY, _, __)
-OC_DECLARE (OC_DEV_PROP_DELETE_MAP)
+#define OC_DEV_PROP_DELETE_MAP_FIELDS(_, __)                                   \
+  OC_MAP(OC_STRING, OC_DEV_PROP_DELETE_ENTRY, _, __)
+OC_DECLARE(OC_DEV_PROP_DELETE_MAP)
 
-#define OC_DEV_PROP_CONFIG_FIELDS(_, __) \
-  _(OC_DEV_PROP_ADD_MAP       , Add              ,     , OC_CONSTR2 (OC_DEV_PROP_ADD_MAP, _, __)    , OC_DESTR (OC_DEV_PROP_ADD_MAP)) \
-  _(OC_DEV_PROP_DELETE_MAP    , Delete           ,     , OC_CONSTR2 (OC_DEV_PROP_DELETE_MAP, _, __) , OC_DESTR (OC_DEV_PROP_DELETE_MAP))
-OC_DECLARE (OC_DEV_PROP_CONFIG)
+#define OC_DEV_PROP_CONFIG_FIELDS(_, __)                                       \
+  _(OC_DEV_PROP_ADD_MAP, Add, , OC_CONSTR2(OC_DEV_PROP_ADD_MAP, _, __),        \
+    OC_DESTR(OC_DEV_PROP_ADD_MAP))                                             \
+  _(OC_DEV_PROP_DELETE_MAP, Delete, ,                                          \
+    OC_CONSTR2(OC_DEV_PROP_DELETE_MAP, _, __),                                 \
+    OC_DESTR(OC_DEV_PROP_DELETE_MAP))
+OC_DECLARE(OC_DEV_PROP_CONFIG)
 
 /**
   KernelSpace section
@@ -197,410 +203,489 @@ OC_DECLARE (OC_DEV_PROP_CONFIG)
 ///
 /// KernelSpace kext adds.
 ///
-#define OC_KERNEL_ADD_ENTRY_FIELDS(_, __) \
-  _(BOOLEAN                     , Enabled          ,     , FALSE                            ,  ()                   ) \
-  _(OC_STRING                   , Arch             ,     , OC_STRING_CONSTR ("Any", _, __)  ,  OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , Comment          ,     , OC_STRING_CONSTR ("", _, __)     ,  OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , MaxKernel        ,     , OC_STRING_CONSTR ("", _, __)     ,  OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , MinKernel        ,     , OC_STRING_CONSTR ("", _, __)     ,  OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , Identifier       ,     , OC_STRING_CONSTR ("", _, __)     ,  OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , BundlePath       ,     , OC_STRING_CONSTR ("", _, __)     ,  OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , ExecutablePath   ,     , OC_STRING_CONSTR ("", _, __)     ,  OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , PlistPath        ,     , OC_STRING_CONSTR ("", _, __)     ,  OC_DESTR (OC_STRING) ) \
-  _(UINT8 *                     , ImageData        ,     , NULL                             ,  OcFreePointer        ) \
-  _(UINT32                      , ImageDataSize    ,     , 0                                ,  ()                   ) \
-  _(CHAR8 *                     , PlistData        ,     , NULL                             ,  OcFreePointer        ) \
-  _(UINT32                      , PlistDataSize    ,     , 0                                ,  ()                   )
-OC_DECLARE (OC_KERNEL_ADD_ENTRY)
+#define OC_KERNEL_ADD_ENTRY_FIELDS(_, __)                                      \
+  _(BOOLEAN, Enabled, , FALSE, ())                                             \
+  _(OC_STRING, Arch, , OC_STRING_CONSTR("Any", _, __), OC_DESTR(OC_STRING))    \
+  _(OC_STRING, Comment, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))    \
+  _(OC_STRING, MaxKernel, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))  \
+  _(OC_STRING, MinKernel, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))  \
+  _(OC_STRING, Identifier, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING)) \
+  _(OC_STRING, BundlePath, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING)) \
+  _(OC_STRING, ExecutablePath, , OC_STRING_CONSTR("", _, __),                  \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, PlistPath, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))  \
+  _(UINT8 *, ImageData, , NULL, OcFreePointer)                                 \
+  _(UINT32, ImageDataSize, , 0, ())                                            \
+  _(CHAR8 *, PlistData, , NULL, OcFreePointer)                                 \
+  _(UINT32, PlistDataSize, , 0, ())
+OC_DECLARE(OC_KERNEL_ADD_ENTRY)
 
-#define OC_KERNEL_ADD_ARRAY_FIELDS(_, __) \
-  OC_ARRAY (OC_KERNEL_ADD_ENTRY, _, __)
-OC_DECLARE (OC_KERNEL_ADD_ARRAY)
+#define OC_KERNEL_ADD_ARRAY_FIELDS(_, __) OC_ARRAY(OC_KERNEL_ADD_ENTRY, _, __)
+OC_DECLARE(OC_KERNEL_ADD_ARRAY)
 
 ///
 /// KernelSpace kext blocks.
 ///
-#define OC_KERNEL_BLOCK_ENTRY_FIELDS(_, __) \
-  _(BOOLEAN                     , Enabled          ,     , FALSE                                ,  ()                   ) \
-  _(OC_STRING                   , Arch             ,     , OC_STRING_CONSTR ("Any", _, __)      ,  OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , Comment          ,     , OC_STRING_CONSTR ("", _, __)         ,  OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , Identifier       ,     , OC_STRING_CONSTR ("", _, __)         ,  OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , MaxKernel        ,     , OC_STRING_CONSTR ("", _, __)         ,  OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , MinKernel        ,     , OC_STRING_CONSTR ("", _, __)         ,  OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , Strategy         ,     , OC_STRING_CONSTR ("Disable", _, __)  ,  OC_DESTR (OC_STRING) )
-OC_DECLARE (OC_KERNEL_BLOCK_ENTRY)
+#define OC_KERNEL_BLOCK_ENTRY_FIELDS(_, __)                                    \
+  _(BOOLEAN, Enabled, , FALSE, ())                                             \
+  _(OC_STRING, Arch, , OC_STRING_CONSTR("Any", _, __), OC_DESTR(OC_STRING))    \
+  _(OC_STRING, Comment, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))    \
+  _(OC_STRING, Identifier, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING)) \
+  _(OC_STRING, MaxKernel, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))  \
+  _(OC_STRING, MinKernel, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))  \
+  _(OC_STRING, Strategy, , OC_STRING_CONSTR("Disable", _, __),                 \
+    OC_DESTR(OC_STRING))
+OC_DECLARE(OC_KERNEL_BLOCK_ENTRY)
 
-#define OC_KERNEL_BLOCK_ARRAY_FIELDS(_, __) \
-  OC_ARRAY (OC_KERNEL_BLOCK_ENTRY, _, __)
-OC_DECLARE (OC_KERNEL_BLOCK_ARRAY)
+#define OC_KERNEL_BLOCK_ARRAY_FIELDS(_, __)                                    \
+  OC_ARRAY(OC_KERNEL_BLOCK_ENTRY, _, __)
+OC_DECLARE(OC_KERNEL_BLOCK_ARRAY)
 
 ///
 /// Kernel emulation preferences.
 ///
-#define OC_KERNEL_EMULATE_FIELDS(_, __) \
-  _(UINT32                      , Cpuid1Data          , [4] , {0}                         , () ) \
-  _(UINT32                      , Cpuid1Mask          , [4] , {0}                         , () ) \
-  _(BOOLEAN                     , DummyPowerManagement,     , FALSE                       , () ) \
-  _(OC_STRING                   , MaxKernel           ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , MinKernel           ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING) )
-OC_DECLARE (OC_KERNEL_EMULATE)
+#define OC_KERNEL_EMULATE_FIELDS(_, __)                                        \
+  _(UINT32, Cpuid1Data, [4], {0}, ())                                          \
+  _(UINT32, Cpuid1Mask, [4], {0}, ())                                          \
+  _(BOOLEAN, DummyPowerManagement, , FALSE, ())                                \
+  _(OC_STRING, MaxKernel, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))  \
+  _(OC_STRING, MinKernel, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))
+OC_DECLARE(OC_KERNEL_EMULATE)
 
 ///
 /// KernelSpace forced loaded kexts.
 ///
-#define OC_KERNEL_FORCE_ARRAY_FIELDS(_, __) \
-  OC_ARRAY (OC_KERNEL_ADD_ENTRY, _, __)
-OC_DECLARE (OC_KERNEL_FORCE_ARRAY)
+#define OC_KERNEL_FORCE_ARRAY_FIELDS(_, __) OC_ARRAY(OC_KERNEL_ADD_ENTRY, _, __)
+OC_DECLARE(OC_KERNEL_FORCE_ARRAY)
 
 ///
 /// KernelSpace patches.
 ///
-#define OC_KERNEL_PATCH_ENTRY_FIELDS(_, __) \
-  _(OC_STRING                   , Arch             ,     , OC_STRING_CONSTR ("Any", _, __), OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , Base             ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , Comment          ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING) ) \
-  _(UINT32                      , Count            ,     , 0                           , ()                   ) \
-  _(BOOLEAN                     , Enabled          ,     , FALSE                       , ()                   ) \
-  _(OC_DATA                     , Find             ,     , OC_EDATA_CONSTR (_, __)     , OC_DESTR (OC_DATA)   ) \
-  _(OC_STRING                   , Identifier       ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING) ) \
-  _(OC_DATA                     , Mask             ,     , OC_EDATA_CONSTR (_, __)     , OC_DESTR (OC_DATA)   ) \
-  _(OC_STRING                   , MaxKernel        ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , MinKernel        ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING) ) \
-  _(OC_DATA                     , Replace          ,     , OC_EDATA_CONSTR (_, __)     , OC_DESTR (OC_DATA)   ) \
-  _(OC_DATA                     , ReplaceMask      ,     , OC_EDATA_CONSTR (_, __)     , OC_DESTR (OC_DATA)   ) \
-  _(UINT32                      , Limit            ,     , 0                           , ()                   ) \
-  _(UINT32                      , Skip             ,     , 0                           , ()                   )
-OC_DECLARE (OC_KERNEL_PATCH_ENTRY)
+#define OC_KERNEL_PATCH_ENTRY_FIELDS(_, __)                                    \
+  _(OC_STRING, Arch, , OC_STRING_CONSTR("Any", _, __), OC_DESTR(OC_STRING))    \
+  _(OC_STRING, Base, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))       \
+  _(OC_STRING, Comment, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))    \
+  _(UINT32, Count, , 0, ())                                                    \
+  _(BOOLEAN, Enabled, , FALSE, ())                                             \
+  _(OC_DATA, Find, , OC_EDATA_CONSTR(_, __), OC_DESTR(OC_DATA))                \
+  _(OC_STRING, Identifier, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING)) \
+  _(OC_DATA, Mask, , OC_EDATA_CONSTR(_, __), OC_DESTR(OC_DATA))                \
+  _(OC_STRING, MaxKernel, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))  \
+  _(OC_STRING, MinKernel, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))  \
+  _(OC_DATA, Replace, , OC_EDATA_CONSTR(_, __), OC_DESTR(OC_DATA))             \
+  _(OC_DATA, ReplaceMask, , OC_EDATA_CONSTR(_, __), OC_DESTR(OC_DATA))         \
+  _(UINT32, Limit, , 0, ())                                                    \
+  _(UINT32, Skip, , 0, ())
+OC_DECLARE(OC_KERNEL_PATCH_ENTRY)
 
-#define OC_KERNEL_PATCH_ARRAY_FIELDS(_, __) \
-  OC_ARRAY (OC_KERNEL_PATCH_ENTRY, _, __)
-OC_DECLARE (OC_KERNEL_PATCH_ARRAY)
+#define OC_KERNEL_PATCH_ARRAY_FIELDS(_, __)                                    \
+  OC_ARRAY(OC_KERNEL_PATCH_ENTRY, _, __)
+OC_DECLARE(OC_KERNEL_PATCH_ARRAY)
 
 ///
 /// KernelSpace quirks.
 ///
-#define OC_KERNEL_QUIRKS_FIELDS(_, __) \
-  _(INT64                       , SetApfsTrimTimeout          ,     , -1     , ()) \
-  _(BOOLEAN                     , AppleCpuPmCfgLock           ,     , FALSE  , ()) \
-  _(BOOLEAN                     , AppleXcpmCfgLock            ,     , FALSE  , ()) \
-  _(BOOLEAN                     , AppleXcpmExtraMsrs          ,     , FALSE  , ()) \
-  _(BOOLEAN                     , AppleXcpmForceBoost         ,     , FALSE  , ()) \
-  _(BOOLEAN                     , CustomPciSerialDevice       ,     , FALSE  , ()) \
-  _(BOOLEAN                     , CustomSmbiosGuid            ,     , FALSE  , ()) \
-  _(BOOLEAN                     , DisableIoMapper             ,     , FALSE  , ()) \
-  _(BOOLEAN                     , DisableIoMapperMapping      ,     , FALSE  , ()) \
-  _(BOOLEAN                     , DisableLinkeditJettison     ,     , FALSE  , ()) \
-  _(BOOLEAN                     , DisableRtcChecksum          ,     , FALSE  , ()) \
-  _(BOOLEAN                     , ExtendBTFeatureFlags        ,     , FALSE  , ()) \
-  _(BOOLEAN                     , ExternalDiskIcons           ,     , FALSE  , ()) \
-  _(BOOLEAN                     , ForceAquantiaEthernet       ,     , FALSE  , ()) \
-  _(BOOLEAN                     , ForceSecureBootScheme       ,     , FALSE  , ()) \
-  _(BOOLEAN                     , IncreasePciBarSize          ,     , FALSE  , ()) \
-  _(BOOLEAN                     , LapicKernelPanic            ,     , FALSE  , ()) \
-  _(BOOLEAN                     , LegacyCommpage              ,     , FALSE  , ()) \
-  _(BOOLEAN                     , PanicNoKextDump             ,     , FALSE  , ()) \
-  _(BOOLEAN                     , PowerTimeoutKernelPanic     ,     , FALSE  , ()) \
-  _(BOOLEAN                     , ProvideCurrentCpuInfo       ,     , FALSE  , ()) \
-  _(BOOLEAN                     , ThirdPartyDrives            ,     , FALSE  , ()) \
-  _(BOOLEAN                     , XhciPortLimit               ,     , FALSE  , ())
-OC_DECLARE (OC_KERNEL_QUIRKS)
+#define OC_KERNEL_QUIRKS_FIELDS(_, __)                                         \
+  _(INT64, SetApfsTrimTimeout, , -1, ())                                       \
+  _(BOOLEAN, AppleCpuPmCfgLock, , FALSE, ())                                   \
+  _(BOOLEAN, AppleXcpmCfgLock, , FALSE, ())                                    \
+  _(BOOLEAN, AppleXcpmExtraMsrs, , FALSE, ())                                  \
+  _(BOOLEAN, AppleXcpmForceBoost, , FALSE, ())                                 \
+  _(BOOLEAN, ClearTaskSwitchBit, , FALSE, ())                                  \
+  _(BOOLEAN, CustomPciSerialDevice, , FALSE, ())                               \
+  _(BOOLEAN, CustomSmbiosGuid, , FALSE, ())                                    \
+  _(BOOLEAN, DisableIoMapper, , FALSE, ())                                     \
+  _(BOOLEAN, DisableIoMapperMapping, , FALSE, ())                              \
+  _(BOOLEAN, DisableLinkeditJettison, , FALSE, ())                             \
+  _(BOOLEAN, DisableRtcChecksum, , FALSE, ())                                  \
+  _(BOOLEAN, ExtendBTFeatureFlags, , FALSE, ())                                \
+  _(BOOLEAN, ExternalDiskIcons, , FALSE, ())                                   \
+  _(BOOLEAN, ForceAquantiaEthernet, , FALSE, ())                               \
+  _(BOOLEAN, ForceSecureBootScheme, , FALSE, ())                               \
+  _(BOOLEAN, IncreasePciBarSize, , FALSE, ())                                  \
+  _(BOOLEAN, LapicKernelPanic, , FALSE, ())                                    \
+  _(BOOLEAN, LegacyCommpage, , FALSE, ())                                      \
+  _(BOOLEAN, PanicNoKextDump, , FALSE, ())                                     \
+  _(BOOLEAN, PowerTimeoutKernelPanic, , FALSE, ())                             \
+  _(BOOLEAN, ProvideCurrentCpuInfo, , FALSE, ())                               \
+  _(BOOLEAN, ThirdPartyDrives, , FALSE, ())                                    \
+  _(BOOLEAN, XhciPortLimit, , FALSE, ())
+OC_DECLARE(OC_KERNEL_QUIRKS)
 
 ///
 /// KernelSpace operation scheme.
 ///
-#define OC_KERNEL_SCHEME_FIELDS(_, __) \
-  _(OC_STRING                   , KernelArch       ,     , OC_STRING_CONSTR ("Auto", _, __), OC_DESTR (OC_STRING)) \
-  _(OC_STRING                   , KernelCache      ,     , OC_STRING_CONSTR ("Auto", _, __), OC_DESTR (OC_STRING)) \
-  _(BOOLEAN                     , CustomKernel     ,     , FALSE  , ()) \
-  _(BOOLEAN                     , FuzzyMatch       ,     , FALSE  , ())
-OC_DECLARE (OC_KERNEL_SCHEME)
+#define OC_KERNEL_SCHEME_FIELDS(_, __)                                         \
+  _(OC_STRING, KernelArch, , OC_STRING_CONSTR("Auto", _, __),                  \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, KernelCache, , OC_STRING_CONSTR("Auto", _, __),                 \
+    OC_DESTR(OC_STRING))                                                       \
+  _(BOOLEAN, CustomKernel, , FALSE, ())                                        \
+  _(BOOLEAN, FuzzyMatch, , FALSE, ())
+OC_DECLARE(OC_KERNEL_SCHEME)
 
-#define OC_KERNEL_CONFIG_FIELDS(_, __) \
-  _(OC_KERNEL_ADD_ARRAY         , Add              ,     , OC_CONSTR2 (OC_KERNEL_ADD_ARRAY, _, __)     , OC_DESTR (OC_KERNEL_ADD_ARRAY)) \
-  _(OC_KERNEL_BLOCK_ARRAY       , Block            ,     , OC_CONSTR2 (OC_KERNEL_BLOCK_ARRAY, _, __)   , OC_DESTR (OC_KERNEL_BLOCK_ARRAY)) \
-  _(OC_KERNEL_EMULATE           , Emulate          ,     , OC_CONSTR2 (OC_KERNEL_EMULATE, _, __)       , OC_DESTR (OC_KERNEL_EMULATE)) \
-  _(OC_KERNEL_FORCE_ARRAY       , Force            ,     , OC_CONSTR2 (OC_KERNEL_FORCE_ARRAY, _, __)   , OC_DESTR (OC_KERNEL_FORCE_ARRAY)) \
-  _(OC_KERNEL_PATCH_ARRAY       , Patch            ,     , OC_CONSTR2 (OC_KERNEL_PATCH_ARRAY, _, __)   , OC_DESTR (OC_KERNEL_PATCH_ARRAY)) \
-  _(OC_KERNEL_QUIRKS            , Quirks           ,     , OC_CONSTR2 (OC_KERNEL_QUIRKS, _, __)        , OC_DESTR (OC_KERNEL_QUIRKS)) \
-  _(OC_KERNEL_SCHEME            , Scheme           ,     , OC_CONSTR2 (OC_KERNEL_SCHEME, _, __)        , OC_DESTR (OC_KERNEL_SCHEME))
-OC_DECLARE (OC_KERNEL_CONFIG)
+#define OC_KERNEL_CONFIG_FIELDS(_, __)                                         \
+  _(OC_KERNEL_ADD_ARRAY, Add, , OC_CONSTR2(OC_KERNEL_ADD_ARRAY, _, __),        \
+    OC_DESTR(OC_KERNEL_ADD_ARRAY))                                             \
+  _(OC_KERNEL_BLOCK_ARRAY, Block, , OC_CONSTR2(OC_KERNEL_BLOCK_ARRAY, _, __),  \
+    OC_DESTR(OC_KERNEL_BLOCK_ARRAY))                                           \
+  _(OC_KERNEL_EMULATE, Emulate, , OC_CONSTR2(OC_KERNEL_EMULATE, _, __),        \
+    OC_DESTR(OC_KERNEL_EMULATE))                                               \
+  _(OC_KERNEL_FORCE_ARRAY, Force, , OC_CONSTR2(OC_KERNEL_FORCE_ARRAY, _, __),  \
+    OC_DESTR(OC_KERNEL_FORCE_ARRAY))                                           \
+  _(OC_KERNEL_PATCH_ARRAY, Patch, , OC_CONSTR2(OC_KERNEL_PATCH_ARRAY, _, __),  \
+    OC_DESTR(OC_KERNEL_PATCH_ARRAY))                                           \
+  _(OC_KERNEL_QUIRKS, Quirks, , OC_CONSTR2(OC_KERNEL_QUIRKS, _, __),           \
+    OC_DESTR(OC_KERNEL_QUIRKS))                                                \
+  _(OC_KERNEL_SCHEME, Scheme, , OC_CONSTR2(OC_KERNEL_SCHEME, _, __),           \
+    OC_DESTR(OC_KERNEL_SCHEME))
+OC_DECLARE(OC_KERNEL_CONFIG)
 
 /**
   Misc section
 **/
 
-#define OC_MISC_BLESS_ARRAY_FIELDS(_, __) \
-  OC_ARRAY (OC_STRING, _, __)
-OC_DECLARE (OC_MISC_BLESS_ARRAY)
+#define OC_MISC_BLESS_ARRAY_FIELDS(_, __) OC_ARRAY(OC_STRING, _, __)
+OC_DECLARE(OC_MISC_BLESS_ARRAY)
 
-#define OC_MISC_BOOT_FIELDS(_, __) \
-  _(OC_STRING                   , PickerMode                  ,     , OC_STRING_CONSTR ("Builtin", _, __) , OC_DESTR (OC_STRING)) \
-  _(OC_STRING                   , HibernateMode               ,     , OC_STRING_CONSTR ("None", _, __)    , OC_DESTR (OC_STRING)) \
-  _(OC_STRING                   , InstanceIdentifier          ,     , OC_STRING_CONSTR ("", _, __)        , OC_DESTR (OC_STRING)) \
-  _(OC_STRING                   , LauncherOption              ,     , OC_STRING_CONSTR ("Disabled", _, __), OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , LauncherPath                ,     , OC_STRING_CONSTR ("Default", _, __) , OC_DESTR (OC_STRING) ) \
-  _(UINT32                      , ConsoleAttributes           ,     , 0                                   , ())                   \
-  _(UINT32                      , PickerAttributes            ,     , 0                                   , ())                   \
-  _(OC_STRING                   , PickerVariant               ,     , OC_STRING_CONSTR ("Auto", _, __)    , OC_DESTR (OC_STRING)) \
-  _(UINT32                      , TakeoffDelay                ,     , 0                                   , ())                   \
-  _(UINT32                      , Timeout                     ,     , 0                                   , ())                   \
-  _(BOOLEAN                     , PickerAudioAssist           ,     , FALSE                               , ())                   \
-  _(BOOLEAN                     , HibernateSkipsPicker        ,     , FALSE                               , ())                   \
-  _(BOOLEAN                     , HideAuxiliary               ,     , FALSE                               , ())                   \
-  _(BOOLEAN                     , PollAppleHotKeys            ,     , FALSE                               , ())                   \
-  _(BOOLEAN                     , ShowPicker                  ,     , FALSE                               , ())
-OC_DECLARE (OC_MISC_BOOT)
+#define OC_MISC_BOOT_FIELDS(_, __)                                             \
+  _(OC_STRING, PickerMode, , OC_STRING_CONSTR("Builtin", _, __),               \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, HibernateMode, , OC_STRING_CONSTR("None", _, __),               \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, InstanceIdentifier, , OC_STRING_CONSTR("", _, __),              \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, LauncherOption, , OC_STRING_CONSTR("Disabled", _, __),          \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, LauncherPath, , OC_STRING_CONSTR("Default", _, __),             \
+    OC_DESTR(OC_STRING))                                                       \
+  _(UINT32, ConsoleAttributes, , 0, ())                                        \
+  _(UINT32, PickerAttributes, , 0, ())                                         \
+  _(OC_STRING, PickerVariant, , OC_STRING_CONSTR("Auto", _, __),               \
+    OC_DESTR(OC_STRING))                                                       \
+  _(UINT32, TakeoffDelay, , 0, ())                                             \
+  _(UINT32, Timeout, , 0, ())                                                  \
+  _(BOOLEAN, PickerAudioAssist, , FALSE, ())                                   \
+  _(BOOLEAN, HibernateSkipsPicker, , FALSE, ())                                \
+  _(BOOLEAN, HideAuxiliary, , FALSE, ())                                       \
+  _(BOOLEAN, PollAppleHotKeys, , FALSE, ())                                    \
+  _(BOOLEAN, ShowPicker, , FALSE, ())
+OC_DECLARE(OC_MISC_BOOT)
 
-#define OC_MISC_DEBUG_FIELDS(_, __) \
-  _(UINT64                      , DisplayLevel                ,     , 0            , ()) \
-  _(UINT32                      , DisplayDelay                ,     , 0            , ()) \
-  _(UINT32                      , Target                      ,     , 0            , ()) \
-  _(BOOLEAN                     , AppleDebug                  ,     , FALSE        , ()) \
-  _(BOOLEAN                     , ApplePanic                  ,     , FALSE        , ()) \
-  _(BOOLEAN                     , DisableWatchDog             ,     , FALSE        , ()) \
-  _(BOOLEAN                     , SysReport                   ,     , FALSE        , ()) \
-  _(OC_STRING                   , LogModules                  ,     , OC_STRING_CONSTR ("*", _, __) , OC_DESTR (OC_STRING))
-OC_DECLARE (OC_MISC_DEBUG)
+#define OC_MISC_DEBUG_FIELDS(_, __)                                            \
+  _(UINT64, DisplayLevel, , 0, ())                                             \
+  _(UINT32, DisplayDelay, , 0, ())                                             \
+  _(UINT32, Target, , 0, ())                                                   \
+  _(BOOLEAN, AppleDebug, , FALSE, ())                                          \
+  _(BOOLEAN, ApplePanic, , FALSE, ())                                          \
+  _(BOOLEAN, DisableWatchDog, , FALSE, ())                                     \
+  _(BOOLEAN, SysReport, , FALSE, ())                                           \
+  _(OC_STRING, LogModules, , OC_STRING_CONSTR("*", _, __), OC_DESTR(OC_STRING))
+OC_DECLARE(OC_MISC_DEBUG)
 
-#define OCS_EXPOSE_BOOT_PATH    1U
-#define OCS_EXPOSE_VERSION_VAR  2U
-#define OCS_EXPOSE_VERSION_UI   4U
-#define OCS_EXPOSE_OEM_INFO     8U
-#define OCS_EXPOSE_VERSION      (OCS_EXPOSE_VERSION_VAR | OCS_EXPOSE_VERSION_UI)
-#define OCS_EXPOSE_ALL_BITS     (\
-  OCS_EXPOSE_BOOT_PATH  | OCS_EXPOSE_VERSION_VAR | \
-  OCS_EXPOSE_VERSION_UI | OCS_EXPOSE_OEM_INFO)
+#define OCS_EXPOSE_BOOT_PATH 1U
+#define OCS_EXPOSE_VERSION_VAR 2U
+#define OCS_EXPOSE_VERSION_UI 4U
+#define OCS_EXPOSE_OEM_INFO 8U
+#define OCS_EXPOSE_VERSION (OCS_EXPOSE_VERSION_VAR | OCS_EXPOSE_VERSION_UI)
+#define OCS_EXPOSE_ALL_BITS                                                    \
+  (OCS_EXPOSE_BOOT_PATH | OCS_EXPOSE_VERSION_VAR | OCS_EXPOSE_VERSION_UI |     \
+   OCS_EXPOSE_OEM_INFO)
 
 typedef enum {
   OcsVaultOptional = 0,
-  OcsVaultBasic    = 1,
-  OcsVaultSecure   = 2,
+  OcsVaultBasic = 1,
+  OcsVaultSecure = 2,
 } OCS_VAULT_MODE;
 
-#define OC_MISC_SECURITY_FIELDS(_, __) \
-  _(OC_STRING                   , Vault                       ,      , OC_STRING_CONSTR ("Secure", _, __), OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , DmgLoading                  ,      , OC_STRING_CONSTR ("Signed", _, __), OC_DESTR (OC_STRING) ) \
-  _(UINT32                      , ScanPolicy                  ,      , OC_SCAN_DEFAULT_POLICY  , ()) \
-  _(UINT32                      , ExposeSensitiveData         ,      , OCS_EXPOSE_VERSION      , ()) \
-  _(BOOLEAN                     , AllowSetDefault             ,      , FALSE                   , ()) \
-  _(BOOLEAN                     , AuthRestart                 ,      , FALSE                   , ()) \
-  _(BOOLEAN                     , BlacklistAppleUpdate        ,      , FALSE                   , ()) \
-  _(BOOLEAN                     , EnablePassword              ,      , FALSE                   , ()) \
-  _(UINT8                       , PasswordHash                , [64] , {0}                     , ()) \
-  _(OC_DATA                     , PasswordSalt                ,      , OC_EDATA_CONSTR (_, __) , OC_DESTR (OC_DATA)) \
-  _(OC_STRING                   , SecureBootModel             ,      , OC_STRING_CONSTR ("Default", _, __), OC_DESTR (OC_STRING) ) \
-  _(UINT64                      , ApECID                      ,      , 0                       , ()) \
-  _(UINT64                      , HaltLevel                   ,      , 0x80000000              , ())
-OC_DECLARE (OC_MISC_SECURITY)
+#define OC_MISC_SECURITY_FIELDS(_, __)                                         \
+  _(OC_STRING, Vault, , OC_STRING_CONSTR("Secure", _, __),                     \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, DmgLoading, , OC_STRING_CONSTR("Signed", _, __),                \
+    OC_DESTR(OC_STRING))                                                       \
+  _(UINT32, ScanPolicy, , OC_SCAN_DEFAULT_POLICY, ())                          \
+  _(UINT32, ExposeSensitiveData, , OCS_EXPOSE_VERSION, ())                     \
+  _(BOOLEAN, AllowSetDefault, , FALSE, ())                                     \
+  _(BOOLEAN, AuthRestart, , FALSE, ())                                         \
+  _(BOOLEAN, BlacklistAppleUpdate, , FALSE, ())                                \
+  _(BOOLEAN, EnablePassword, , FALSE, ())                                      \
+  _(UINT8, PasswordHash, [64], {0}, ())                                        \
+  _(OC_DATA, PasswordSalt, , OC_EDATA_CONSTR(_, __), OC_DESTR(OC_DATA))        \
+  _(OC_STRING, SecureBootModel, , OC_STRING_CONSTR("Default", _, __),          \
+    OC_DESTR(OC_STRING))                                                       \
+  _(UINT64, ApECID, , 0, ())                                                   \
+  _(UINT64, HaltLevel, , 0x80000000, ())
+OC_DECLARE(OC_MISC_SECURITY)
 
-#define OC_MISC_TOOLS_ENTRY_FIELDS(_, __) \
-  _(OC_STRING                   , Arguments       ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , Comment         ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , Flavour         ,     , OC_STRING_CONSTR ("Auto", _, __), OC_DESTR (OC_STRING) ) \
-  _(BOOLEAN                     , Auxiliary       ,     , FALSE                       , ()                   ) \
-  _(BOOLEAN                     , Enabled         ,     , FALSE                       , ()                   ) \
-  _(BOOLEAN                     , FullNvramAccess ,     , FALSE                       , ()                   ) \
-  _(BOOLEAN                     , RealPath        ,     , FALSE                       , ()                   ) \
-  _(BOOLEAN                     , TextMode        ,     , FALSE                       , ()                   ) \
-  _(OC_STRING                   , Name            ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , Path            ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING) )
-OC_DECLARE (OC_MISC_TOOLS_ENTRY)
+#define OC_MISC_TOOLS_ENTRY_FIELDS(_, __)                                      \
+  _(OC_STRING, Arguments, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))  \
+  _(OC_STRING, Comment, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))    \
+  _(OC_STRING, Flavour, , OC_STRING_CONSTR("Auto", _, __),                     \
+    OC_DESTR(OC_STRING))                                                       \
+  _(BOOLEAN, Auxiliary, , FALSE, ())                                           \
+  _(BOOLEAN, Enabled, , FALSE, ())                                             \
+  _(BOOLEAN, FullNvramAccess, , FALSE, ())                                     \
+  _(BOOLEAN, RealPath, , FALSE, ())                                            \
+  _(BOOLEAN, TextMode, , FALSE, ())                                            \
+  _(OC_STRING, Name, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))       \
+  _(OC_STRING, Path, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))
+OC_DECLARE(OC_MISC_TOOLS_ENTRY)
 
-#define OC_MISC_TOOLS_ARRAY_FIELDS(_, __) \
-  OC_ARRAY (OC_MISC_TOOLS_ENTRY, _, __)
-OC_DECLARE (OC_MISC_TOOLS_ARRAY)
+#define OC_MISC_TOOLS_ARRAY_FIELDS(_, __) OC_ARRAY(OC_MISC_TOOLS_ENTRY, _, __)
+OC_DECLARE(OC_MISC_TOOLS_ARRAY)
 
 ///
 /// Reference:
 /// https://github.com/acidanthera/bugtracker/issues/1954#issuecomment-1084220743
 ///
-#define OC_SERIAL_PCI_DEVICE_INFO_MAX_SIZE  41U
+#define OC_SERIAL_PCI_DEVICE_INFO_MAX_SIZE 41U
 
 ///
 /// Reference:
 /// https://github.com/acidanthera/audk/blob/master/MdeModulePkg/Library/BaseSerialPortLib16550/BaseSerialPortLib16550.inf
 /// https://github.com/acidanthera/audk/blob/master/MdeModulePkg/MdeModulePkg.dec
 ///
-#define OC_MISC_SERIAL_CUSTOM_FIELDS(_, __) \
-  _(UINT32                      , BaudRate                 ,      , 115200                           , ()) \
-  _(UINT32                      , ClockRate                ,      , 1843200                          , ()) \
-  _(BOOLEAN                     , DetectCable              ,      , FALSE                            , ()) \
-  _(UINT32                      , ExtendedTxFifoSize       ,      , 64                               , ()) \
-  _(UINT8                       , FifoControl              ,      , 7                                , ()) \
-  _(UINT8                       , LineControl              ,      , 3                                , ()) \
-  _(OC_DATA                     , PciDeviceInfo            ,      , OC_DATA_CONSTR ({0xFF}, _, __)   , OC_DESTR (OC_DATA)) \
-  _(UINT8                       , RegisterAccessWidth      ,      , 8                                , ()) \
-  _(UINT64                      , RegisterBase             ,      , 0x03F8                           , ()) \
-  _(UINT32                      , RegisterStride           ,      , 1                                , ()) \
-  _(BOOLEAN                     , UseHardwareFlowControl   ,      , FALSE                            , ()) \
-  _(BOOLEAN                     , UseMmio                  ,      , FALSE                            , ())
-OC_DECLARE (OC_MISC_SERIAL_CUSTOM)
+#define OC_MISC_SERIAL_CUSTOM_FIELDS(_, __)                                    \
+  _(UINT32, BaudRate, , 115200, ())                                            \
+  _(UINT32, ClockRate, , 1843200, ())                                          \
+  _(BOOLEAN, DetectCable, , FALSE, ())                                         \
+  _(UINT32, ExtendedTxFifoSize, , 64, ())                                      \
+  _(UINT8, FifoControl, , 7, ())                                               \
+  _(UINT8, LineControl, , 3, ())                                               \
+  _(OC_DATA, PciDeviceInfo, , OC_DATA_CONSTR({0xFF}, _, __),                   \
+    OC_DESTR(OC_DATA))                                                         \
+  _(UINT8, RegisterAccessWidth, , 8, ())                                       \
+  _(UINT64, RegisterBase, , 0x03F8, ())                                        \
+  _(UINT32, RegisterStride, , 1, ())                                           \
+  _(BOOLEAN, UseHardwareFlowControl, , FALSE, ())                              \
+  _(BOOLEAN, UseMmio, , FALSE, ())
+OC_DECLARE(OC_MISC_SERIAL_CUSTOM)
 
-#define OC_MISC_SERIAL_FIELDS(_, __) \
-  _(OC_MISC_SERIAL_CUSTOM              , Custom    ,     , OC_CONSTR3 (OC_MISC_SERIAL_CUSTOM, _, __)         , OC_DESTR (OC_MISC_SERIAL_CUSTOM)) \
-  _(BOOLEAN                            , Init      ,     , FALSE                                             , ()) \
-  _(BOOLEAN                            , Override  ,     , FALSE                                             , ())
-OC_DECLARE (OC_MISC_SERIAL)
+#define OC_MISC_SERIAL_FIELDS(_, __)                                           \
+  _(OC_MISC_SERIAL_CUSTOM, Custom, , OC_CONSTR3(OC_MISC_SERIAL_CUSTOM, _, __), \
+    OC_DESTR(OC_MISC_SERIAL_CUSTOM))                                           \
+  _(BOOLEAN, Init, , FALSE, ())                                                \
+  _(BOOLEAN, Override, , FALSE, ())
+OC_DECLARE(OC_MISC_SERIAL)
 
-#define OC_MISC_CONFIG_FIELDS(_, __) \
-  _(OC_MISC_BLESS_ARRAY        , BlessOverride   ,     , OC_CONSTR2 (OC_MISC_BLESS_ARRAY, _, __)  , OC_DESTR (OC_MISC_BLESS_ARRAY)) \
-  _(OC_MISC_BOOT               , Boot            ,     , OC_CONSTR2 (OC_MISC_BOOT, _, __)         , OC_DESTR (OC_MISC_BOOT)) \
-  _(OC_MISC_DEBUG              , Debug           ,     , OC_CONSTR2 (OC_MISC_DEBUG, _, __)        , OC_DESTR (OC_MISC_DEBUG)) \
-  _(OC_MISC_SECURITY           , Security        ,     , OC_CONSTR2 (OC_MISC_SECURITY, _, __)     , OC_DESTR (OC_MISC_SECURITY)) \
-  _(OC_MISC_SERIAL             , Serial          ,     , OC_CONSTR2 (OC_MISC_SERIAL, _, __)       , OC_DESTR (OC_MISC_SERIAL)) \
-  _(OC_MISC_TOOLS_ARRAY        , Entries         ,     , OC_CONSTR2 (OC_MISC_TOOLS_ARRAY, _, __)  , OC_DESTR (OC_MISC_TOOLS_ARRAY)) \
-  _(OC_MISC_TOOLS_ARRAY        , Tools           ,     , OC_CONSTR2 (OC_MISC_TOOLS_ARRAY, _, __)  , OC_DESTR (OC_MISC_TOOLS_ARRAY))
-OC_DECLARE (OC_MISC_CONFIG)
+#define OC_MISC_CONFIG_FIELDS(_, __)                                           \
+  _(OC_MISC_BLESS_ARRAY, BlessOverride, ,                                      \
+    OC_CONSTR2(OC_MISC_BLESS_ARRAY, _, __), OC_DESTR(OC_MISC_BLESS_ARRAY))     \
+  _(OC_MISC_BOOT, Boot, , OC_CONSTR2(OC_MISC_BOOT, _, __),                     \
+    OC_DESTR(OC_MISC_BOOT))                                                    \
+  _(OC_MISC_DEBUG, Debug, , OC_CONSTR2(OC_MISC_DEBUG, _, __),                  \
+    OC_DESTR(OC_MISC_DEBUG))                                                   \
+  _(OC_MISC_SECURITY, Security, , OC_CONSTR2(OC_MISC_SECURITY, _, __),         \
+    OC_DESTR(OC_MISC_SECURITY))                                                \
+  _(OC_MISC_SERIAL, Serial, , OC_CONSTR2(OC_MISC_SERIAL, _, __),               \
+    OC_DESTR(OC_MISC_SERIAL))                                                  \
+  _(OC_MISC_TOOLS_ARRAY, Entries, , OC_CONSTR2(OC_MISC_TOOLS_ARRAY, _, __),    \
+    OC_DESTR(OC_MISC_TOOLS_ARRAY))                                             \
+  _(OC_MISC_TOOLS_ARRAY, Tools, , OC_CONSTR2(OC_MISC_TOOLS_ARRAY, _, __),      \
+    OC_DESTR(OC_MISC_TOOLS_ARRAY))
+OC_DECLARE(OC_MISC_CONFIG)
 
 /**
   NVRAM section
 **/
 
 ///
-/// NVRAM values is an associative map of GUIDS with their property key value maps.
+/// NVRAM values is an associative map of GUIDS with their property key value
+/// maps.
 ///
-#define OC_NVRAM_ADD_MAP_FIELDS(_, __) \
-  OC_MAP (OC_STRING, OC_ASSOC, _, __)
-OC_DECLARE (OC_NVRAM_ADD_MAP)
+#define OC_NVRAM_ADD_MAP_FIELDS(_, __) OC_MAP(OC_STRING, OC_ASSOC, _, __)
+OC_DECLARE(OC_NVRAM_ADD_MAP)
 
-#define OC_NVRAM_DELETE_ENTRY_FIELDS(_, __) \
-  OC_ARRAY (OC_STRING, _, __)
-OC_DECLARE (OC_NVRAM_DELETE_ENTRY)
+#define OC_NVRAM_DELETE_ENTRY_FIELDS(_, __) OC_ARRAY(OC_STRING, _, __)
+OC_DECLARE(OC_NVRAM_DELETE_ENTRY)
 
-#define OC_NVRAM_DELETE_MAP_FIELDS(_, __) \
-  OC_MAP (OC_STRING, OC_NVRAM_DELETE_ENTRY, _, __)
-OC_DECLARE (OC_NVRAM_DELETE_MAP)
+#define OC_NVRAM_DELETE_MAP_FIELDS(_, __)                                      \
+  OC_MAP(OC_STRING, OC_NVRAM_DELETE_ENTRY, _, __)
+OC_DECLARE(OC_NVRAM_DELETE_MAP)
 
-#define OC_NVRAM_LEGACY_ENTRY_FIELDS(_, __) \
-  OC_ARRAY (OC_STRING, _, __)
-OC_DECLARE (OC_NVRAM_LEGACY_ENTRY)
+#define OC_NVRAM_LEGACY_ENTRY_FIELDS(_, __) OC_ARRAY(OC_STRING, _, __)
+OC_DECLARE(OC_NVRAM_LEGACY_ENTRY)
 
-#define OC_NVRAM_LEGACY_MAP_FIELDS(_, __) \
-  OC_MAP (OC_STRING, OC_NVRAM_LEGACY_ENTRY, _, __)
-OC_DECLARE (OC_NVRAM_LEGACY_MAP)
+#define OC_NVRAM_LEGACY_MAP_FIELDS(_, __)                                      \
+  OC_MAP(OC_STRING, OC_NVRAM_LEGACY_ENTRY, _, __)
+OC_DECLARE(OC_NVRAM_LEGACY_MAP)
 
-#define OC_NVRAM_CONFIG_FIELDS(_, __) \
-  _(OC_NVRAM_ADD_MAP           , Add               ,     , OC_CONSTR2 (OC_NVRAM_ADD_MAP, _, __)        , OC_DESTR (OC_NVRAM_ADD_MAP)) \
-  _(OC_NVRAM_DELETE_MAP        , Delete            ,     , OC_CONSTR2 (OC_NVRAM_DELETE_MAP, _, __)     , OC_DESTR (OC_NVRAM_DELETE_MAP)) \
-  _(OC_NVRAM_LEGACY_MAP        , Legacy            ,     , OC_CONSTR2 (OC_NVRAM_LEGACY_MAP, _, __)     , OC_DESTR (OC_NVRAM_LEGACY_MAP)) \
-  _(BOOLEAN                    , LegacyOverwrite   ,     , FALSE                                       , () ) \
-  _(BOOLEAN                    , WriteFlash        ,     , FALSE                                       , () )
-OC_DECLARE (OC_NVRAM_CONFIG)
+#define OC_NVRAM_CONFIG_FIELDS(_, __)                                          \
+  _(OC_NVRAM_ADD_MAP, Add, , OC_CONSTR2(OC_NVRAM_ADD_MAP, _, __),              \
+    OC_DESTR(OC_NVRAM_ADD_MAP))                                                \
+  _(OC_NVRAM_DELETE_MAP, Delete, , OC_CONSTR2(OC_NVRAM_DELETE_MAP, _, __),     \
+    OC_DESTR(OC_NVRAM_DELETE_MAP))                                             \
+  _(OC_NVRAM_LEGACY_MAP, Legacy, , OC_CONSTR2(OC_NVRAM_LEGACY_MAP, _, __),     \
+    OC_DESTR(OC_NVRAM_LEGACY_MAP))                                             \
+  _(BOOLEAN, LegacyOverwrite, , FALSE, ())                                     \
+  _(BOOLEAN, WriteFlash, , FALSE, ())
+OC_DECLARE(OC_NVRAM_CONFIG)
 
 /**
   Platform information configuration
 **/
 
-#define OC_PLATFORM_GENERIC_CONFIG_FIELDS(_, __) \
-  _(OC_STRING                   , SystemProductName  ,     , OC_STRING_CONSTR ("", _, __)                 , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , SystemSerialNumber ,     , OC_STRING_CONSTR ("", _, __)                 , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , SystemUuid         ,     , OC_STRING_CONSTR ("", _, __)                 , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , Mlb                ,     , OC_STRING_CONSTR ("", _, __)                 , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , SystemMemoryStatus ,     , OC_STRING_CONSTR ("Auto", _, __)             , OC_DESTR (OC_STRING) ) \
-  _(UINT16                      , ProcessorType      ,     , 0                                            , () )                   \
-  _(UINT8                       , Rom                , [6] , {0}                                          , () )                   \
-  _(BOOLEAN                     , SpoofVendor        ,     , FALSE                                        , () )                   \
-  _(BOOLEAN                     , AdviseFeatures     ,     , FALSE                                        , () )                   \
-  _(BOOLEAN                     , MaxBIOSVersion     ,     , FALSE                                        , () )
-OC_DECLARE (OC_PLATFORM_GENERIC_CONFIG)
+#define OC_PLATFORM_GENERIC_CONFIG_FIELDS(_, __)                               \
+  _(OC_STRING, SystemProductName, , OC_STRING_CONSTR("", _, __),               \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, SystemSerialNumber, , OC_STRING_CONSTR("", _, __),              \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, SystemUuid, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING)) \
+  _(OC_STRING, Mlb, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))        \
+  _(OC_STRING, SystemMemoryStatus, , OC_STRING_CONSTR("Auto", _, __),          \
+    OC_DESTR(OC_STRING))                                                       \
+  _(UINT16, ProcessorType, , 0, ())                                            \
+  _(UINT8, Rom, [6], {0}, ())                                                  \
+  _(BOOLEAN, SpoofVendor, , FALSE, ())                                         \
+  _(BOOLEAN, AdviseFeatures, , FALSE, ())                                      \
+  _(BOOLEAN, MaxBIOSVersion, , FALSE, ())
+OC_DECLARE(OC_PLATFORM_GENERIC_CONFIG)
 
-#define OC_PLATFORM_DATA_HUB_CONFIG_FIELDS(_, __) \
-  _(OC_STRING                   , PlatformName        ,     , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , SystemProductName   ,     , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , SystemSerialNumber  ,     , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , SystemUuid          ,     , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , BoardProduct        ,     , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(UINT8                       , BoardRevision       , [1] , {0}                              , () )                   \
-  _(UINT64                      , StartupPowerEvents  ,     , 0                                , () )                   \
-  _(UINT64                      , InitialTSC          ,     , 0                                , () )                   \
-  _(UINT64                      , FSBFrequency        ,     , 0                                , () )                   \
-  _(UINT64                      , ARTFrequency        ,     , 0                                , () )                   \
-  _(UINT32                      , DevicePathsSupported,     , 0                                , () )                   \
-  _(UINT8                       , SmcRevision         , [6] , {0}                              , () )                   \
-  _(UINT8                       , SmcBranch           , [8] , {0}                              , () )                   \
-  _(UINT8                       , SmcPlatform         , [8] , {0}                              , () )
-OC_DECLARE (OC_PLATFORM_DATA_HUB_CONFIG)
+#define OC_PLATFORM_DATA_HUB_CONFIG_FIELDS(_, __)                              \
+  _(OC_STRING, PlatformName, , OC_STRING_CONSTR("", _, __),                    \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, SystemProductName, , OC_STRING_CONSTR("", _, __),               \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, SystemSerialNumber, , OC_STRING_CONSTR("", _, __),              \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, SystemUuid, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING)) \
+  _(OC_STRING, BoardProduct, , OC_STRING_CONSTR("", _, __),                    \
+    OC_DESTR(OC_STRING))                                                       \
+  _(UINT8, BoardRevision, [1], {0}, ())                                        \
+  _(UINT64, StartupPowerEvents, , 0, ())                                       \
+  _(UINT64, InitialTSC, , 0, ())                                               \
+  _(UINT64, FSBFrequency, , 0, ())                                             \
+  _(UINT64, ARTFrequency, , 0, ())                                             \
+  _(UINT32, DevicePathsSupported, , 0, ())                                     \
+  _(UINT8, SmcRevision, [6], {0}, ())                                          \
+  _(UINT8, SmcBranch, [8], {0}, ())                                            \
+  _(UINT8, SmcPlatform, [8], {0}, ())
+OC_DECLARE(OC_PLATFORM_DATA_HUB_CONFIG)
 
-#define OC_PLATFORM_MEMORY_DEVICE_ENTRY_FIELDS(_, __) \
-  _(UINT32                      , Size                ,     , 0                                  , () )                   \
-  _(UINT16                      , Speed               ,     , 0                                  , () )                   \
-  _(OC_STRING                   , DeviceLocator       ,     , OC_STRING_CONSTR ("Unknown", _, __), OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , BankLocator         ,     , OC_STRING_CONSTR ("Unknown", _, __), OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , Manufacturer        ,     , OC_STRING_CONSTR ("Unknown", _, __), OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , SerialNumber        ,     , OC_STRING_CONSTR ("Unknown", _, __), OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , AssetTag            ,     , OC_STRING_CONSTR ("Unknown", _, __), OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , PartNumber          ,     , OC_STRING_CONSTR ("Unknown", _, __), OC_DESTR (OC_STRING) )
-OC_DECLARE (OC_PLATFORM_MEMORY_DEVICE_ENTRY)
+#define OC_PLATFORM_MEMORY_DEVICE_ENTRY_FIELDS(_, __)                          \
+  _(UINT32, Size, , 0, ())                                                     \
+  _(UINT16, Speed, , 0, ())                                                    \
+  _(OC_STRING, DeviceLocator, , OC_STRING_CONSTR("Unknown", _, __),            \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, BankLocator, , OC_STRING_CONSTR("Unknown", _, __),              \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, Manufacturer, , OC_STRING_CONSTR("Unknown", _, __),             \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, SerialNumber, , OC_STRING_CONSTR("Unknown", _, __),             \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, AssetTag, , OC_STRING_CONSTR("Unknown", _, __),                 \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, PartNumber, , OC_STRING_CONSTR("Unknown", _, __),               \
+    OC_DESTR(OC_STRING))
+OC_DECLARE(OC_PLATFORM_MEMORY_DEVICE_ENTRY)
 
-#define OC_PLATFORM_MEMORY_DEVICES_ARRAY_FIELDS(_, __) \
-  OC_ARRAY (OC_PLATFORM_MEMORY_DEVICE_ENTRY, _, __)
-OC_DECLARE (OC_PLATFORM_MEMORY_DEVICES_ARRAY)
+#define OC_PLATFORM_MEMORY_DEVICES_ARRAY_FIELDS(_, __)                         \
+  OC_ARRAY(OC_PLATFORM_MEMORY_DEVICE_ENTRY, _, __)
+OC_DECLARE(OC_PLATFORM_MEMORY_DEVICES_ARRAY)
 
-#define OC_PLATFORM_MEMORY_CONFIG_FIELDS(_, __) \
-  _(UINT8                           , FormFactor     ,     , 0x2                                                 , () ) \
-  _(UINT8                           , Type           ,     , 0x2                                                 , () ) \
-  _(UINT16                          , TypeDetail     ,     , 0x4                                                 , () ) \
-  _(UINT16                          , TotalWidth     ,     , 0xFFFF                                              , () ) \
-  _(UINT16                          , DataWidth      ,     , 0xFFFF                                              , () ) \
-  _(UINT8                           , ErrorCorrection,     , 0x3                                                 , () ) \
-  _(UINT64                          , MaxCapacity    ,     , 0                                                   , () ) \
-  _(OC_PLATFORM_MEMORY_DEVICES_ARRAY, Devices        ,     , OC_CONSTR3 (OC_PLATFORM_MEMORY_DEVICES_ARRAY, _, __), OC_DESTR (OC_PLATFORM_MEMORY_DEVICES_ARRAY))
-OC_DECLARE (OC_PLATFORM_MEMORY_CONFIG)
+#define OC_PLATFORM_MEMORY_CONFIG_FIELDS(_, __)                                \
+  _(UINT8, FormFactor, , 0x2, ())                                              \
+  _(UINT8, Type, , 0x2, ())                                                    \
+  _(UINT16, TypeDetail, , 0x4, ())                                             \
+  _(UINT16, TotalWidth, , 0xFFFF, ())                                          \
+  _(UINT16, DataWidth, , 0xFFFF, ())                                           \
+  _(UINT8, ErrorCorrection, , 0x3, ())                                         \
+  _(UINT64, MaxCapacity, , 0, ())                                              \
+  _(OC_PLATFORM_MEMORY_DEVICES_ARRAY, Devices, ,                               \
+    OC_CONSTR3(OC_PLATFORM_MEMORY_DEVICES_ARRAY, _, __),                       \
+    OC_DESTR(OC_PLATFORM_MEMORY_DEVICES_ARRAY))
+OC_DECLARE(OC_PLATFORM_MEMORY_CONFIG)
 
-#define OC_PLATFORM_NVRAM_CONFIG_FIELDS(_, __) \
-  _(OC_STRING                   , Bid                   ,     , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , Mlb                   ,     , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , SystemSerialNumber    ,     , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , SystemUuid            ,     , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(UINT8                       , Rom                   , [6] , {0}                              , ()                   ) \
-  _(UINT64                      , FirmwareFeatures      ,     , 0                                , ()                   ) \
-  _(UINT64                      , FirmwareFeaturesMask  ,     , 0                                , ()                   )
-OC_DECLARE (OC_PLATFORM_NVRAM_CONFIG)
+///
+/// Array of driver names to unload.
+///
+#define OC_UEFI_UNLOAD_ARRAY_FIELDS(_, __) OC_ARRAY(OC_STRING, _, __)
+OC_DECLARE(OC_UEFI_UNLOAD_ARRAY)
 
-#define OC_PLATFORM_SMBIOS_CONFIG_FIELDS(_, __) \
-  _(OC_STRING                    , BIOSVendor            ,  , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                    , BIOSVersion           ,  , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                    , BIOSReleaseDate       ,  , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                    , SystemManufacturer    ,  , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                    , SystemProductName     ,  , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                    , SystemVersion         ,  , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                    , SystemSerialNumber    ,  , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                    , SystemUuid            ,  , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                    , SystemSKUNumber       ,  , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                    , SystemFamily          ,  , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                    , BoardManufacturer     ,  , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                    , BoardProduct          ,  , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                    , BoardVersion          ,  , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                    , BoardSerialNumber     ,  , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                    , BoardAssetTag         ,  , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(UINT8                        , BoardType             ,  , 0                                , ()                   ) \
-  _(OC_STRING                    , BoardLocationInChassis,  , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                    , ChassisManufacturer   ,  , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(UINT8                        , ChassisType           ,  , 0                                , ()                   ) \
-  _(OC_STRING                    , ChassisVersion        ,  , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                    , ChassisSerialNumber   ,  , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                    , ChassisAssetTag       ,  , OC_STRING_CONSTR ("", _, __)     , OC_DESTR (OC_STRING) ) \
-  _(UINT32                       , PlatformFeature       ,  , 0xFFFFFFFFU                      , ()                   ) \
-  _(UINT64                       , FirmwareFeatures      ,  , 0                                , ()                   ) \
-  _(UINT64                       , FirmwareFeaturesMask  ,  , 0                                , ()                   ) \
-  _(UINT8                        , SmcVersion            , [16] , {0}                          , ()                   ) \
-  _(UINT16                       , ProcessorType         ,  , 0                                , ()                   )
-OC_DECLARE (OC_PLATFORM_SMBIOS_CONFIG)
+///#define OC_PLATFORM_NVRAM_CONFIG_FIELDS(_, __)                                 \
+  _(OC_STRING, Bid, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))        \
+  _(OC_STRING, Mlb, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))        \
+  _(OC_STRING, SystemSerialNumber, , OC_STRING_CONSTR("", _, __),              \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, SystemUuid, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING)) \
+  _(UINT8, Rom, [6], {0}, ())                                                  \
+  _(UINT64, FirmwareFeatures, , 0, ())                                         \
+  _(UINT64, FirmwareFeaturesMask, , 0, ())
+OC_DECLARE(OC_PLATFORM_NVRAM_CONFIG)
 
-#define OC_PLATFORM_CONFIG_FIELDS(_, __) \
-  _(BOOLEAN                     , Automatic          ,     , FALSE                                           , ()) \
-  _(BOOLEAN                     , CustomMemory       ,     , FALSE                                           , ()) \
-  _(BOOLEAN                     , UpdateDataHub      ,     , FALSE                                           , ()) \
-  _(BOOLEAN                     , UpdateNvram        ,     , FALSE                                           , ()) \
-  _(BOOLEAN                     , UpdateSmbios       ,     , FALSE                                           , ()) \
-  _(BOOLEAN                     , UseRawUuidEncoding ,     , FALSE                                           , ()) \
-  _(OC_STRING                   , UpdateSmbiosMode   ,     , OC_STRING_CONSTR ("Create", _, __)              , OC_DESTR (OC_STRING) ) \
-  _(OC_PLATFORM_GENERIC_CONFIG  , Generic            ,     , OC_CONSTR2 (OC_PLATFORM_GENERIC_CONFIG, _, __)  , OC_DESTR (OC_PLATFORM_GENERIC_CONFIG)) \
-  _(OC_PLATFORM_DATA_HUB_CONFIG , DataHub            ,     , OC_CONSTR2 (OC_PLATFORM_DATA_HUB_CONFIG, _, __) , OC_DESTR (OC_PLATFORM_DATA_HUB_CONFIG)) \
-  _(OC_PLATFORM_MEMORY_CONFIG   , Memory             ,     , OC_CONSTR2 (OC_PLATFORM_MEMORY_CONFIG, _, __)   , OC_DESTR (OC_PLATFORM_MEMORY_CONFIG)) \
-  _(OC_PLATFORM_NVRAM_CONFIG    , Nvram              ,     , OC_CONSTR2 (OC_PLATFORM_NVRAM_CONFIG, _, __)    , OC_DESTR (OC_PLATFORM_NVRAM_CONFIG)) \
-  _(OC_PLATFORM_SMBIOS_CONFIG   , Smbios             ,     , OC_CONSTR2 (OC_PLATFORM_SMBIOS_CONFIG, _, __)   , OC_DESTR (OC_PLATFORM_SMBIOS_CONFIG))
-OC_DECLARE (OC_PLATFORM_CONFIG)
+#define OC_PLATFORM_SMBIOS_CONFIG_FIELDS(_, __)                                \
+  _(OC_STRING, BIOSVendor, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING)) \
+  _(OC_STRING, BIOSVersion, , OC_STRING_CONSTR("", _, __),                     \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, BIOSReleaseDate, , OC_STRING_CONSTR("", _, __),                 \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, SystemManufacturer, , OC_STRING_CONSTR("", _, __),              \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, SystemProductName, , OC_STRING_CONSTR("", _, __),               \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, SystemVersion, , OC_STRING_CONSTR("", _, __),                   \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, SystemSerialNumber, , OC_STRING_CONSTR("", _, __),              \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, SystemUuid, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING)) \
+  _(OC_STRING, SystemSKUNumber, , OC_STRING_CONSTR("", _, __),                 \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, SystemFamily, , OC_STRING_CONSTR("", _, __),                    \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, BoardManufacturer, , OC_STRING_CONSTR("", _, __),               \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, BoardProduct, , OC_STRING_CONSTR("", _, __),                    \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, BoardVersion, , OC_STRING_CONSTR("", _, __),                    \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, BoardSerialNumber, , OC_STRING_CONSTR("", _, __),               \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, BoardAssetTag, , OC_STRING_CONSTR("", _, __),                   \
+    OC_DESTR(OC_STRING))                                                       \
+  _(UINT8, BoardType, , 0, ())                                                 \
+  _(OC_STRING, BoardLocationInChassis, , OC_STRING_CONSTR("", _, __),          \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, ChassisManufacturer, , OC_STRING_CONSTR("", _, __),             \
+    OC_DESTR(OC_STRING))                                                       \
+  _(UINT8, ChassisType, , 0, ())                                               \
+  _(OC_STRING, ChassisVersion, , OC_STRING_CONSTR("", _, __),                  \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, ChassisSerialNumber, , OC_STRING_CONSTR("", _, __),             \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, ChassisAssetTag, , OC_STRING_CONSTR("", _, __),                 \
+    OC_DESTR(OC_STRING))                                                       \
+  _(UINT32, PlatformFeature, , 0xFFFFFFFFU, ())                                \
+  _(UINT64, FirmwareFeatures, , 0, ())                                         \
+  _(UINT64, FirmwareFeaturesMask, , 0, ())                                     \
+  _(UINT8, SmcVersion, [16], {0}, ())                                          \
+  _(UINT16, ProcessorType, , 0, ())
+OC_DECLARE(OC_PLATFORM_SMBIOS_CONFIG)
+
+#define OC_PLATFORM_CONFIG_FIELDS(_, __)                                       \
+  _(BOOLEAN, Automatic, , FALSE, ())                                           \
+  _(BOOLEAN, CustomMemory, , FALSE, ())                                        \
+  _(BOOLEAN, UpdateDataHub, , FALSE, ())                                       \
+  _(BOOLEAN, UpdateNvram, , FALSE, ())                                         \
+  _(BOOLEAN, UpdateSmbios, , FALSE, ())                                        \
+  _(BOOLEAN, UseRawUuidEncoding, , FALSE, ())                                  \
+  _(OC_STRING, UpdateSmbiosMode, , OC_STRING_CONSTR("Create", _, __),          \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_PLATFORM_GENERIC_CONFIG, Generic, ,                                     \
+    OC_CONSTR2(OC_PLATFORM_GENERIC_CONFIG, _, __),                             \
+    OC_DESTR(OC_PLATFORM_GENERIC_CONFIG))                                      \
+  _(OC_PLATFORM_DATA_HUB_CONFIG, DataHub, ,                                    \
+    OC_CONSTR2(OC_PLATFORM_DATA_HUB_CONFIG, _, __),                            \
+    OC_DESTR(OC_PLATFORM_DATA_HUB_CONFIG))                                     \
+  _(OC_PLATFORM_MEMORY_CONFIG, Memory, ,                                       \
+    OC_CONSTR2(OC_PLATFORM_MEMORY_CONFIG, _, __),                              \
+    OC_DESTR(OC_PLATFORM_MEMORY_CONFIG))                                       \
+  _(OC_PLATFORM_NVRAM_CONFIG, Nvram, ,                                         \
+    OC_CONSTR2(OC_PLATFORM_NVRAM_CONFIG, _, __),                               \
+    OC_DESTR(OC_PLATFORM_NVRAM_CONFIG))                                        \
+  _(OC_PLATFORM_SMBIOS_CONFIG, Smbios, ,                                       \
+    OC_CONSTR2(OC_PLATFORM_SMBIOS_CONFIG, _, __),                              \
+    OC_DESTR(OC_PLATFORM_SMBIOS_CONFIG))
+OC_DECLARE(OC_PLATFORM_CONFIG)
 
 /**
   Uefi section
@@ -609,196 +694,226 @@ OC_DECLARE (OC_PLATFORM_CONFIG)
 ///
 /// Drivers is an ordered array of drivers to load.
 ///
-#define OC_UEFI_DRIVER_ENTRY_FIELDS(_, __) \
-  _(OC_STRING                   , Arguments          ,     , OC_STRING_CONSTR ("", _, __)                    , OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , Comment            ,     , OC_STRING_CONSTR ("", _, __)                    , OC_DESTR (OC_STRING) ) \
-  _(BOOLEAN                     , Enabled            ,     , FALSE                                           , ()) \
-  _(BOOLEAN                     , LoadEarly          ,     , FALSE                                           , ()) \
-  _(OC_STRING                   , Path               ,     , OC_STRING_CONSTR ("", _, __)                    , OC_DESTR (OC_STRING) )
-OC_DECLARE (OC_UEFI_DRIVER_ENTRY)
+#define OC_UEFI_DRIVER_ENTRY_FIELDS(_, __)                                     \
+  _(OC_STRING, Arguments, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))  \
+  _(OC_STRING, Comment, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))    \
+  _(BOOLEAN, Enabled, , FALSE, ())                                             \
+  _(BOOLEAN, LoadEarly, , FALSE, ())                                           \
+  _(OC_STRING, Path, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))
+OC_DECLARE(OC_UEFI_DRIVER_ENTRY)
 
-#define OC_UEFI_DRIVER_ARRAY_FIELDS(_, __) \
-  OC_ARRAY (OC_UEFI_DRIVER_ENTRY, _, __)
-OC_DECLARE (OC_UEFI_DRIVER_ARRAY)
+#define OC_UEFI_DRIVER_ARRAY_FIELDS(_, __) OC_ARRAY(OC_UEFI_DRIVER_ENTRY, _, __)
+OC_DECLARE(OC_UEFI_DRIVER_ARRAY)
 
 ///
 /// APFS is a set of options for APFS file system support.
 ///
-#define OC_UEFI_APFS_FIELDS(_, __) \
-  _(UINT64                      , MinVersion         ,     , 0                             , ()) \
-  _(UINT32                      , MinDate            ,     , 0                             , ()) \
-  _(BOOLEAN                     , EnableJumpstart    ,     , FALSE                         , ()) \
-  _(BOOLEAN                     , GlobalConnect      ,     , FALSE                         , ()) \
-  _(BOOLEAN                     , HideVerbose        ,     , FALSE                         , ()) \
-  _(BOOLEAN                     , JumpstartHotPlug   ,     , FALSE                         , ())
-OC_DECLARE (OC_UEFI_APFS)
+#define OC_UEFI_APFS_FIELDS(_, __)                                             \
+  _(UINT64, MinVersion, , 0, ())                                               \
+  _(UINT32, MinDate, , 0, ())                                                  \
+  _(BOOLEAN, EnableJumpstart, , FALSE, ())                                     \
+  _(BOOLEAN, GlobalConnect, , FALSE, ())                                       \
+  _(BOOLEAN, HideVerbose, , FALSE, ())                                         \
+  _(BOOLEAN, JumpstartHotPlug, , FALSE, ())
+OC_DECLARE(OC_UEFI_APFS)
 
 ///
-/// AppleInput is a set of options to configure OpenCore's reverse engingeered then customised implementation of the AppleEvent protocol.
+/// AppleInput is a set of options to configure OpenCore's reverse engingeered
+/// then customised implementation of the AppleEvent protocol.
 ///
-#define OC_UEFI_APPLEINPUT_FIELDS(_, __) \
-  _(OC_STRING                   , AppleEvent                    ,     , OC_STRING_CONSTR ("Auto", _, __)  , OC_DESTR (OC_STRING) ) \
-  _(BOOLEAN                     , CustomDelays                  ,     , FALSE                             , ()) \
-  _(UINT16                      , KeyInitialDelay               ,     , 50                                , ()) \
-  _(UINT16                      , KeySubsequentDelay            ,     , 5                                 , ()) \
-  _(BOOLEAN                     , GraphicsInputMirroring        ,     , FALSE                             , ()) \
-  _(UINT32                      , PointerPollMin                ,     , 0                                 , ()) \
-  _(UINT32                      , PointerPollMax                ,     , 0                                 , ()) \
-  _(UINT32                      , PointerPollMask               ,     , ((UINT32) (-1))                   , ()) \
-  _(UINT16                      , PointerSpeedDiv               ,     , 1                                 , ()) \
-  _(UINT16                      , PointerSpeedMul               ,     , 1                                 , ()) \
-  _(UINT16                      , PointerDwellClickTimeout      ,     , 0                                 , ()) \
-  _(UINT16                      , PointerDwellDoubleClickTimeout,     , 0                                 , ()) \
-  _(UINT16                      , PointerDwellRadius            ,     , 0                                 , ())
-OC_DECLARE (OC_UEFI_APPLEINPUT)
+#define OC_UEFI_APPLEINPUT_FIELDS(_, __)                                       \
+  _(OC_STRING, AppleEvent, , OC_STRING_CONSTR("Auto", _, __),                  \
+    OC_DESTR(OC_STRING))                                                       \
+  _(BOOLEAN, CustomDelays, , FALSE, ())                                        \
+  _(UINT16, KeyInitialDelay, , 50, ())                                         \
+  _(UINT16, KeySubsequentDelay, , 5, ())                                       \
+  _(BOOLEAN, GraphicsInputMirroring, , FALSE, ())                              \
+  _(UINT32, PointerPollMin, , 0, ())                                           \
+  _(UINT32, PointerPollMax, , 0, ())                                           \
+  _(UINT32, PointerPollMask, , ((UINT32)(-1)), ())                             \
+  _(UINT16, PointerSpeedDiv, , 1, ())                                          \
+  _(UINT16, PointerSpeedMul, , 1, ())                                          \
+  _(UINT16, PointerDwellClickTimeout, , 0, ())                                 \
+  _(UINT16, PointerDwellDoubleClickTimeout, , 0, ())                           \
+  _(UINT16, PointerDwellRadius, , 0, ())
+OC_DECLARE(OC_UEFI_APPLEINPUT)
 
 ///
 /// Audio is a set of options for sound configuration.
 ///
-#define OC_UEFI_AUDIO_FIELDS(_, __) \
-  _(OC_STRING                   , AudioDevice        ,     , OC_STRING_CONSTR ("", _, __)      , OC_DESTR (OC_STRING)) \
-  _(OC_STRING                   , PlayChime          ,     , OC_STRING_CONSTR ("Auto", _, __)  , OC_DESTR (OC_STRING)) \
-  _(UINT32                      , SetupDelay         ,     , 0                                 , ()) \
-  _(BOOLEAN                     , AudioSupport       ,     , FALSE                             , ()) \
-  _(UINT64                      , AudioOutMask       ,     , MAX_UINT64                        , ()) \
-  _(UINT8                       , AudioCodec         ,     , 0                                 , ()) \
-  _(INT8                        , MaximumGain        ,     , -15                               , ()) \
-  _(INT8                        , MinimumAssistGain  ,     , -30                               , ()) \
-  _(INT8                        , MinimumAudibleGain ,     , -128                              , ()) \
-  _(BOOLEAN                     , ResetTrafficClass  ,     , FALSE                             , ()) \
-  _(BOOLEAN                     , DisconnectHda      ,     , FALSE                             , ())
-OC_DECLARE (OC_UEFI_AUDIO)
+#define OC_UEFI_AUDIO_FIELDS(_, __)                                            \
+  _(OC_STRING, AudioDevice, , OC_STRING_CONSTR("", _, __),                     \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, PlayChime, , OC_STRING_CONSTR("Auto", _, __),                   \
+    OC_DESTR(OC_STRING))                                                       \
+  _(UINT32, SetupDelay, , 0, ())                                               \
+  _(BOOLEAN, AudioSupport, , FALSE, ())                                        \
+  _(UINT64, AudioOutMask, , MAX_UINT64, ())                                    \
+  _(UINT8, AudioCodec, , 0, ())                                                \
+  _(INT8, MaximumGain, , -15, ())                                              \
+  _(INT8, MinimumAssistGain, , -30, ())                                        \
+  _(INT8, MinimumAudibleGain, , -128, ())                                      \
+  _(BOOLEAN, ResetTrafficClass, , FALSE, ())                                   \
+  _(BOOLEAN, DisconnectHda, , FALSE, ())
+OC_DECLARE(OC_UEFI_AUDIO)
 
 ///
 /// Input is a set of options to support advanced input.
 ///
-#define OC_UEFI_INPUT_FIELDS(_, __) \
-  _(OC_STRING                   , KeySupportMode     ,     , OC_STRING_CONSTR ("Auto", _, __)  , OC_DESTR (OC_STRING)) \
-  _(OC_STRING                   , PointerSupportMode ,     , OC_STRING_CONSTR ("", _, __)      , OC_DESTR (OC_STRING)) \
-  _(UINT32                      , TimerResolution    ,     , 0                                 , ()) \
-  _(UINT8                       , KeyForgetThreshold ,     , 0                                 , ()) \
-  _(BOOLEAN                     , KeySupport         ,     , FALSE                             , ()) \
-  _(BOOLEAN                     , KeyFiltering       ,     , FALSE                             , ()) \
-  _(BOOLEAN                     , KeySwap            ,     , FALSE                             , ()) \
-  _(BOOLEAN                     , PointerSupport     ,     , FALSE                             , ())
-OC_DECLARE (OC_UEFI_INPUT)
+#define OC_UEFI_INPUT_FIELDS(_, __)                                            \
+  _(OC_STRING, KeySupportMode, , OC_STRING_CONSTR("Auto", _, __),              \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, PointerSupportMode, , OC_STRING_CONSTR("", _, __),              \
+    OC_DESTR(OC_STRING))                                                       \
+  _(UINT32, TimerResolution, , 0, ())                                          \
+  _(UINT8, KeyForgetThreshold, , 0, ())                                        \
+  _(BOOLEAN, KeySupport, , FALSE, ())                                          \
+  _(BOOLEAN, KeyFiltering, , FALSE, ())                                        \
+  _(BOOLEAN, KeySwap, , FALSE, ())                                             \
+  _(BOOLEAN, PointerSupport, , FALSE, ())
+OC_DECLARE(OC_UEFI_INPUT)
 
 ///
 /// Output is a set of options to support advanced output.
 ///
-#define OC_UEFI_OUTPUT_FIELDS(_, __) \
-  _(OC_STRING                   , ConsoleMode                 ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING)) \
-  _(OC_STRING                   , ConsoleFont                 ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING)) \
-  _(OC_STRING                   , Resolution                  ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING)) \
-  _(OC_STRING                   , InitialMode                 ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING)) \
-  _(OC_STRING                   , TextRenderer                ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING)) \
-  _(OC_STRING                   , GopPassThrough              ,     , OC_STRING_CONSTR ("Disabled", _, __), OC_DESTR (OC_STRING)) \
-  _(BOOLEAN                     , IgnoreTextInGraphics        ,     , FALSE  , ()) \
-  _(BOOLEAN                     , ClearScreenOnModeSwitch     ,     , FALSE  , ()) \
-  _(BOOLEAN                     , ProvideConsoleGop           ,     , FALSE  , ()) \
-  _(BOOLEAN                     , ReplaceTabWithSpace         ,     , FALSE  , ()) \
-  _(BOOLEAN                     , ReconnectOnResChange        ,     , FALSE  , ()) \
-  _(BOOLEAN                     , SanitiseClearScreen         ,     , FALSE  , ()) \
-  _(INT8                        , UIScale                     ,     , -1     , ()) \
-  _(BOOLEAN                     , UgaPassThrough              ,     , FALSE  , ()) \
-  _(BOOLEAN                     , DirectGopRendering          ,     , FALSE  , ()) \
-  _(BOOLEAN                     , ForceResolution             ,     , FALSE  , ()) \
-  _(BOOLEAN                     , GopBurstMode                ,     , FALSE  , ()) \
-  _(BOOLEAN                     , ReconnectGraphicsOnConnect  ,     , FALSE  , ())
-OC_DECLARE (OC_UEFI_OUTPUT)
+#define OC_UEFI_OUTPUT_FIELDS(_, __)                                           \
+  _(OC_STRING, ConsoleMode, , OC_STRING_CONSTR("", _, __),                     \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, ConsoleFont, , OC_STRING_CONSTR("", _, __),                     \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, Resolution, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING)) \
+  _(OC_STRING, InitialMode, , OC_STRING_CONSTR("", _, __),                     \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, TextRenderer, , OC_STRING_CONSTR("", _, __),                    \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, GopPassThrough, , OC_STRING_CONSTR("Disabled", _, __),          \
+    OC_DESTR(OC_STRING))                                                       \
+  _(BOOLEAN, IgnoreTextInGraphics, , FALSE, ())                                \
+  _(BOOLEAN, ClearScreenOnModeSwitch, , FALSE, ())                             \
+  _(BOOLEAN, ProvideConsoleGop, , FALSE, ())                                   \
+  _(BOOLEAN, ReplaceTabWithSpace, , FALSE, ())                                 \
+  _(BOOLEAN, ReconnectOnResChange, , FALSE, ())                                \
+  _(BOOLEAN, SanitiseClearScreen, , FALSE, ())                                 \
+  _(INT8, UIScale, , -1, ())                                                   \
+  _(BOOLEAN, UgaPassThrough, , FALSE, ())                                      \
+  _(BOOLEAN, DirectGopRendering, , FALSE, ())                                  \
+  _(BOOLEAN, ForceResolution, , FALSE, ())                                     \
+  _(BOOLEAN, GopBurstMode, , FALSE, ())                                        \
+  _(BOOLEAN, ReconnectGraphicsOnConnect, , FALSE, ())
+OC_DECLARE(OC_UEFI_OUTPUT)
 
 ///
 /// Prefer own protocol implementation for these protocols.
 ///
-#define OC_UEFI_PROTOCOL_OVERRIDES_FIELDS(_, __) \
-  _(BOOLEAN                     , AppleAudio                  ,     , FALSE  , ()) \
-  _(BOOLEAN                     , AppleBootPolicy             ,     , FALSE  , ()) \
-  _(BOOLEAN                     , AppleDebugLog               ,     , FALSE  , ()) \
-  _(BOOLEAN                     , AppleEg2Info                ,     , FALSE  , ()) \
-  _(BOOLEAN                     , AppleFramebufferInfo        ,     , FALSE  , ()) \
-  _(BOOLEAN                     , AppleImageConversion        ,     , FALSE  , ()) \
-  _(BOOLEAN                     , AppleImg4Verification       ,     , FALSE  , ()) \
-  _(BOOLEAN                     , AppleKeyMap                 ,     , FALSE  , ()) \
-  _(BOOLEAN                     , AppleRtcRam                 ,     , FALSE  , ()) \
-  _(BOOLEAN                     , AppleSecureBoot             ,     , FALSE  , ()) \
-  _(BOOLEAN                     , AppleSmcIo                  ,     , FALSE  , ()) \
-  _(BOOLEAN                     , AppleUserInterfaceTheme     ,     , FALSE  , ()) \
-  _(BOOLEAN                     , DataHub                     ,     , FALSE  , ()) \
-  _(BOOLEAN                     , DeviceProperties            ,     , FALSE  , ()) \
-  _(BOOLEAN                     , FirmwareVolume              ,     , FALSE  , ()) \
-  _(BOOLEAN                     , HashServices                ,     , FALSE  , ()) \
-  _(BOOLEAN                     , OSInfo                      ,     , FALSE  , ()) \
-  _(BOOLEAN                     , PciIo                       ,     , FALSE  , ()) \
-  _(BOOLEAN                     , UnicodeCollation            ,     , FALSE  , ())
-OC_DECLARE (OC_UEFI_PROTOCOL_OVERRIDES)
+#define OC_UEFI_PROTOCOL_OVERRIDES_FIELDS(_, __)                               \
+  _(BOOLEAN, AppleAudio, , FALSE, ())                                          \
+  _(BOOLEAN, AppleBootPolicy, , FALSE, ())                                     \
+  _(BOOLEAN, AppleDebugLog, , FALSE, ())                                       \
+  _(BOOLEAN, AppleEg2Info, , FALSE, ())                                        \
+  _(BOOLEAN, AppleFramebufferInfo, , FALSE, ())                                \
+  _(BOOLEAN, AppleImageConversion, , FALSE, ())                                \
+  _(BOOLEAN, AppleImg4Verification, , FALSE, ())                               \
+  _(BOOLEAN, AppleKeyMap, , FALSE, ())                                         \
+  _(BOOLEAN, AppleRtcRam, , FALSE, ())                                         \
+  _(BOOLEAN, AppleSecureBoot, , FALSE, ())                                     \
+  _(BOOLEAN, AppleSmcIo, , FALSE, ())                                          \
+  _(BOOLEAN, AppleUserInterfaceTheme, , FALSE, ())                             \
+  _(BOOLEAN, DataHub, , FALSE, ())                                             \
+  _(BOOLEAN, DeviceProperties, , FALSE, ())                                    \
+  _(BOOLEAN, FirmwareVolume, , FALSE, ())                                      \
+  _(BOOLEAN, HashServices, , FALSE, ())                                        \
+  _(BOOLEAN, OSInfo, , FALSE, ())                                              \
+  _(BOOLEAN, PciIo, , FALSE, ())                                               \
+  _(BOOLEAN, UnicodeCollation, , FALSE, ())
+OC_DECLARE(OC_UEFI_PROTOCOL_OVERRIDES)
 
 ///
 /// Quirks is a set of hacks for different types of firmware.
 ///
-#define OC_UEFI_QUIRKS_FIELDS(_, __) \
-  _(UINT32                      , ExitBootServicesDelay       ,     , 0      , ()) \
-  _(UINT32                      , TscSyncTimeout              ,     , 0      , ()) \
-  _(BOOLEAN                     , ActivateHpetSupport         ,     , FALSE  , ()) \
-  _(BOOLEAN                     , DisableSecurityPolicy       ,     , FALSE  , ()) \
-  _(BOOLEAN                     , EnableVectorAcceleration    ,     , FALSE  , ()) \
-  _(BOOLEAN                     , EnableVmx                   ,     , FALSE  , ()) \
-  _(BOOLEAN                     , ForgeUefiSupport            ,     , FALSE  , ()) \
-  _(BOOLEAN                     , IgnoreInvalidFlexRatio      ,     , FALSE  , ()) \
-  _(INT8                        , ResizeGpuBars               ,     , -1     , ()) \
-  _(BOOLEAN                     , ResizeUsePciRbIo            ,     , FALSE  , ()) \
-  _(BOOLEAN                     , ReleaseUsbOwnership         ,     , FALSE  , ()) \
-  _(BOOLEAN                     , ReloadOptionRoms            ,     , FALSE  , ()) \
-  _(BOOLEAN                     , RequestBootVarRouting       ,     , FALSE  , ()) \
-  _(BOOLEAN                     , ShimRetainProtocol          ,     , FALSE  , ()) \
-  _(BOOLEAN                     , UnblockFsConnect            ,     , FALSE  , ()) \
-  _(BOOLEAN                     , ForceOcWriteFlash           ,     , FALSE  , ())
-OC_DECLARE (OC_UEFI_QUIRKS)
+#define OC_UEFI_QUIRKS_FIELDS(_, __)                                           \
+  _(UINT32, ExitBootServicesDelay, , 0, ())                                    \
+  _(UINT32, TscSyncTimeout, , 0, ())                                           \
+  _(BOOLEAN, ActivateHpetSupport, , FALSE, ())                                 \
+  _(BOOLEAN, DisableSecurityPolicy, , FALSE, ())                               \
+  _(BOOLEAN, EnableVectorAcceleration, , FALSE, ())                            \
+  _(BOOLEAN, EnableVmx, , FALSE, ())                                           \
+  _(BOOLEAN, ForgeUefiSupport, , FALSE, ())                                    \
+  _(BOOLEAN, IgnoreInvalidFlexRatio, , FALSE, ())                              \
+  _(INT8, ResizeGpuBars, , -1, ())                                             \
+  _(BOOLEAN, ResizeUsePciRbIo, , FALSE, ())                                    \
+  _(BOOLEAN, ReleaseUsbOwnership, , FALSE, ())                                 \
+  _(BOOLEAN, ReloadOptionRoms, , FALSE, ())                                    \
+  _(BOOLEAN, RequestBootVarRouting, , FALSE, ())                               \
+  _(BOOLEAN, ShimRetainProtocol, , FALSE, ())                                  \
+  _(BOOLEAN, UnblockFsConnect, , FALSE, ())                                    \
+  _(BOOLEAN, ForceOcWriteFlash, , FALSE, ())
+OC_DECLARE(OC_UEFI_QUIRKS)
 
 ///
 /// Reserved memory entries adds.
 ///
-#define OC_UEFI_RSVD_ENTRY_FIELDS(_, __) \
-  _(UINT64                      , Address          ,     , 0       , () ) \
-  _(UINT64                      , Size             ,     , 0       , () ) \
-  _(BOOLEAN                     , Enabled          ,     , FALSE   , () ) \
-  _(OC_STRING                   , Type             ,     , OC_STRING_CONSTR ("Reserved", _, __), OC_DESTR (OC_STRING) ) \
-  _(OC_STRING                   , Comment          ,     , OC_STRING_CONSTR ("", _, __), OC_DESTR (OC_STRING) )
-OC_DECLARE (OC_UEFI_RSVD_ENTRY)
+#define OC_UEFI_RSVD_ENTRY_FIELDS(_, __)                                       \
+  _(UINT64, Address, , 0, ())                                                  \
+  _(UINT64, Size, , 0, ())                                                     \
+  _(BOOLEAN, Enabled, , FALSE, ())                                             \
+  _(OC_STRING, Type, , OC_STRING_CONSTR("Reserved", _, __),                    \
+    OC_DESTR(OC_STRING))                                                       \
+  _(OC_STRING, Comment, , OC_STRING_CONSTR("", _, __), OC_DESTR(OC_STRING))
+OC_DECLARE(OC_UEFI_RSVD_ENTRY)
 
-#define OC_UEFI_RSVD_ARRAY_FIELDS(_, __) \
-  OC_ARRAY (OC_UEFI_RSVD_ENTRY, _, __)
-OC_DECLARE (OC_UEFI_RSVD_ARRAY)
+#define OC_UEFI_RSVD_ARRAY_FIELDS(_, __) OC_ARRAY(OC_UEFI_RSVD_ENTRY, _, __)
+OC_DECLARE(OC_UEFI_RSVD_ARRAY)
 
 ///
 /// Uefi contains firmware tweaks and extra drivers.
 ///
-#define OC_UEFI_CONFIG_FIELDS(_, __) \
-  _(BOOLEAN                     , ConnectDrivers    ,     , FALSE                                          , ()) \
-  _(OC_UEFI_APFS                , Apfs              ,     , OC_CONSTR2 (OC_UEFI_APFS, _, __)               , OC_DESTR (OC_UEFI_APFS)) \
-  _(OC_UEFI_APPLEINPUT          , AppleInput        ,     , OC_CONSTR2 (OC_UEFI_APPLEINPUT, _, __)         , OC_DESTR (OC_UEFI_APPLEINPUT)) \
-  _(OC_UEFI_AUDIO               , Audio             ,     , OC_CONSTR2 (OC_UEFI_AUDIO, _, __)              , OC_DESTR (OC_UEFI_AUDIO)) \
-  _(OC_UEFI_DRIVER_ARRAY        , Drivers           ,     , OC_CONSTR2 (OC_UEFI_DRIVER_ARRAY, _, __)       , OC_DESTR (OC_UEFI_DRIVER_ARRAY)) \
-  _(OC_UEFI_INPUT               , Input             ,     , OC_CONSTR2 (OC_UEFI_INPUT, _, __)              , OC_DESTR (OC_UEFI_INPUT)) \
-  _(OC_UEFI_OUTPUT              , Output            ,     , OC_CONSTR2 (OC_UEFI_OUTPUT, _, __)             , OC_DESTR (OC_UEFI_OUTPUT)) \
-  _(OC_UEFI_PROTOCOL_OVERRIDES  , ProtocolOverrides ,     , OC_CONSTR2 (OC_UEFI_PROTOCOL_OVERRIDES, _, __) , OC_DESTR (OC_UEFI_PROTOCOL_OVERRIDES)) \
-  _(OC_UEFI_QUIRKS              , Quirks            ,     , OC_CONSTR2 (OC_UEFI_QUIRKS, _, __)             , OC_DESTR (OC_UEFI_QUIRKS)) \
-  _(OC_UEFI_RSVD_ARRAY          , ReservedMemory    ,     , OC_CONSTR2 (OC_UEFI_RSVD_ARRAY, _, __)         , OC_DESTR (OC_UEFI_RSVD_ARRAY))
-OC_DECLARE (OC_UEFI_CONFIG)
+#define OC_UEFI_CONFIG_FIELDS(_, __)                                           \
+  _(BOOLEAN, ConnectDrivers, , FALSE, ())                                      \
+  _(OC_UEFI_APFS, Apfs, , OC_CONSTR2(OC_UEFI_APFS, _, __),                     \
+    OC_DESTR(OC_UEFI_APFS))                                                    \
+  _(OC_UEFI_APPLEINPUT, AppleInput, , OC_CONSTR2(OC_UEFI_APPLEINPUT, _, __),   \
+    OC_DESTR(OC_UEFI_APPLEINPUT))                                              \
+  _(OC_UEFI_AUDIO, Audio, , OC_CONSTR2(OC_UEFI_AUDIO, _, __),                  \
+    OC_DESTR(OC_UEFI_AUDIO))                                                   \
+  _(OC_UEFI_DRIVER_ARRAY, Drivers, , OC_CONSTR2(OC_UEFI_DRIVER_ARRAY, _, __),  \
+    OC_DESTR(OC_UEFI_DRIVER_ARRAY))                                            \
+  _(OC_UEFI_INPUT, Input, , OC_CONSTR2(OC_UEFI_INPUT, _, __),                  \
+    OC_DESTR(OC_UEFI_INPUT))                                                   \
+  _(OC_UEFI_OUTPUT, Output, , OC_CONSTR2(OC_UEFI_OUTPUT, _, __),               \
+    OC_DESTR(OC_UEFI_OUTPUT))                                                  \
+  _(OC_UEFI_PROTOCOL_OVERRIDES, ProtocolOverrides, ,                           \
+    OC_CONSTR2(OC_UEFI_PROTOCOL_OVERRIDES, _, __),                             \
+    OC_DESTR(OC_UEFI_PROTOCOL_OVERRIDES))                                      \
+  _(OC_UEFI_QUIRKS, Quirks, , OC_CONSTR2(OC_UEFI_QUIRKS, _, __),               \
+    OC_DESTR(OC_UEFI_QUIRKS))                                                  \
+  _(OC_UEFI_RSVD_ARRAY, ReservedMemory, ,                                      \
+    OC_CONSTR2(OC_UEFI_RSVD_ARRAY, _, __), OC_DESTR(OC_UEFI_RSVD_ARRAY))       \
+  _(OC_UEFI_UNLOAD_ARRAY, Unload, , OC_CONSTR2(OC_UEFI_UNLOAD_ARRAY, _, __),   \
+    OC_DESTR(OC_UEFI_UNLOAD_ARRAY))
+OC_DECLARE(OC_UEFI_CONFIG)
 
 /**
   Root configuration
 **/
 
-#define OC_GLOBAL_CONFIG_FIELDS(_, __) \
-  _(OC_ACPI_CONFIG              , Acpi              ,     , OC_CONSTR1 (OC_ACPI_CONFIG, _, __)      , OC_DESTR (OC_ACPI_CONFIG)) \
-  _(OC_BOOTER_CONFIG            , Booter            ,     , OC_CONSTR1 (OC_BOOTER_CONFIG, _, __)    , OC_DESTR (OC_BOOTER_CONFIG)) \
-  _(OC_DEV_PROP_CONFIG          , DeviceProperties  ,     , OC_CONSTR1 (OC_DEV_PROP_CONFIG, _, __)  , OC_DESTR (OC_DEV_PROP_CONFIG)) \
-  _(OC_KERNEL_CONFIG            , Kernel            ,     , OC_CONSTR1 (OC_KERNEL_CONFIG, _, __)    , OC_DESTR (OC_KERNEL_CONFIG)) \
-  _(OC_MISC_CONFIG              , Misc              ,     , OC_CONSTR1 (OC_MISC_CONFIG, _, __)      , OC_DESTR (OC_MISC_CONFIG)) \
-  _(OC_NVRAM_CONFIG             , Nvram             ,     , OC_CONSTR1 (OC_NVRAM_CONFIG, _, __)     , OC_DESTR (OC_NVRAM_CONFIG)) \
-  _(OC_PLATFORM_CONFIG          , PlatformInfo      ,     , OC_CONSTR1 (OC_PLATFORM_CONFIG, _, __)  , OC_DESTR (OC_PLATFORM_CONFIG)) \
-  _(OC_UEFI_CONFIG              , Uefi              ,     , OC_CONSTR1 (OC_UEFI_CONFIG, _, __)      , OC_DESTR (OC_UEFI_CONFIG))
-OC_DECLARE (OC_GLOBAL_CONFIG)
+#define OC_GLOBAL_CONFIG_FIELDS(_, __)                                         \
+  _(OC_ACPI_CONFIG, Acpi, , OC_CONSTR1(OC_ACPI_CONFIG, _, __),                 \
+    OC_DESTR(OC_ACPI_CONFIG))                                                  \
+  _(OC_BOOTER_CONFIG, Booter, , OC_CONSTR1(OC_BOOTER_CONFIG, _, __),           \
+    OC_DESTR(OC_BOOTER_CONFIG))                                                \
+  _(OC_DEV_PROP_CONFIG, DeviceProperties, ,                                    \
+    OC_CONSTR1(OC_DEV_PROP_CONFIG, _, __), OC_DESTR(OC_DEV_PROP_CONFIG))       \
+  _(OC_KERNEL_CONFIG, Kernel, , OC_CONSTR1(OC_KERNEL_CONFIG, _, __),           \
+    OC_DESTR(OC_KERNEL_CONFIG))                                                \
+  _(OC_MISC_CONFIG, Misc, , OC_CONSTR1(OC_MISC_CONFIG, _, __),                 \
+    OC_DESTR(OC_MISC_CONFIG))                                                  \
+  _(OC_NVRAM_CONFIG, Nvram, , OC_CONSTR1(OC_NVRAM_CONFIG, _, __),              \
+    OC_DESTR(OC_NVRAM_CONFIG))                                                 \
+  _(OC_PLATFORM_CONFIG, PlatformInfo, , OC_CONSTR1(OC_PLATFORM_CONFIG, _, __), \
+    OC_DESTR(OC_PLATFORM_CONFIG))                                              \
+  _(OC_UEFI_CONFIG, Uefi, , OC_CONSTR1(OC_UEFI_CONFIG, _, __),                 \
+    OC_DESTR(OC_UEFI_CONFIG))
+OC_DECLARE(OC_GLOBAL_CONFIG)
 
 /**
   Initialize configuration with plist data.
@@ -811,21 +926,14 @@ OC_DECLARE (OC_GLOBAL_CONFIG)
   @retval  EFI_SUCCESS on success
 **/
 EFI_STATUS
-OcConfigurationInit (
-  OUT  OC_GLOBAL_CONFIG  *Config,
-  IN       VOID          *Buffer,
-  IN       UINT32        Size,
-  IN  OUT  UINT32        *ErrorCount  OPTIONAL
-  );
+OcConfigurationInit(OUT OC_GLOBAL_CONFIG *Config, IN VOID *Buffer,
+                    IN UINT32 Size, IN OUT UINT32 *ErrorCount OPTIONAL);
 
 /**
   Free configuration structure.
 
   @param[in,out]  Config   Configuration structure.
 **/
-VOID
-OcConfigurationFree (
-  IN OUT OC_GLOBAL_CONFIG  *Config
-  );
+VOID OcConfigurationFree(IN OUT OC_GLOBAL_CONFIG *Config);
 
 #endif // OC_CONFIGURATION_LIB_H

--- a/Include/Intel/IndustryStandard/ProcessorInfo.h
+++ b/Include/Intel/IndustryStandard/ProcessorInfo.h
@@ -4,9 +4,9 @@
   All rights reserved.
 
   This program and the accompanying materials
-  are licensed and made available under the terms and conditions of the BSD License
-  which accompanies this distribution.  The full text of the license may be found at
-  http://opensource.org/licenses/bsd-license.php
+  are licensed and made available under the terms and conditions of the BSD
+License which accompanies this distribution.  The full text of the license may
+be found at http://opensource.org/licenses/bsd-license.php
 
   THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
   WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
@@ -17,268 +17,281 @@
 
 // SandyBridge/IvyBridge bus clock is fixed at 100MHz
 
-#define BRIDGE_BCLK  100
+#define BRIDGE_BCLK 100
 
-#define BASE_NHM_CLOCK_SOURCE  133333333ULL
+#define BASE_NHM_CLOCK_SOURCE 133333333ULL
 
 //
 // Skylake bus clock is fixed at 100MHz
 // This constant is also known as BASE_ART_CLOCK_SOURCE in XNU
 //
-#define CLIENT_ART_CLOCK_SOURCE  24000000ULL
-#define SERVER_ART_CLOCK_SOURCE  25000000ULL
-#define ATOM_ART_CLOCK_SOURCE    19200000ULL
+#define CLIENT_ART_CLOCK_SOURCE 24000000ULL
+#define SERVER_ART_CLOCK_SOURCE 25000000ULL
+#define ATOM_ART_CLOCK_SOURCE 19200000ULL
 
-#define DEFAULT_ART_CLOCK_SOURCE  CLIENT_ART_CLOCK_SOURCE
+#define DEFAULT_ART_CLOCK_SOURCE CLIENT_ART_CLOCK_SOURCE
 
-#define MSR_PIC_MSG_CONTROL    0x2E
-#define MSR_CORE_THREAD_COUNT  0x35
+#define MSR_PIC_MSG_CONTROL 0x2E
+#define MSR_CORE_THREAD_COUNT 0x35
 
-#define EFI_PLATFORM_INFORMATION                        0x000000CE
-#define N_EFI_PLATFORM_INFO_MIN_RATIO                   40
-#define B_EFI_PLATFORM_INFO_RATIO_MASK                  0xFF
-#define N_EFI_PLATFORM_INFO_MAX_RATIO                   8
-#define B_EFI_PLATFORM_INFO_TDC_TDP_LIMIT               (1 << 29)
-#define N_EFI_PLATFORM_INFO_RATIO_LIMIT                 28
-#define B_EFI_PLATFORM_INFO_RATIO_LIMIT                 (1 << 28)
-#define B_EFI_PLATFORM_INFO_SMM_SAVE_CONTROL            (1 << 16)
-#define N_EFI_PLATFORM_INFO_PROG_TCC_ACTIVATION_OFFSET  30
-#define B_EFI_PLATFORM_INFO_PROG_TCC_ACTIVATION_OFFSET  (1 << 30)
+#define EFI_PLATFORM_INFORMATION 0x000000CE
+#define N_EFI_PLATFORM_INFO_MIN_RATIO 40
+#define B_EFI_PLATFORM_INFO_RATIO_MASK 0xFF
+#define N_EFI_PLATFORM_INFO_MAX_RATIO 8
+#define B_EFI_PLATFORM_INFO_TDC_TDP_LIMIT (1 << 29)
+#define N_EFI_PLATFORM_INFO_RATIO_LIMIT 28
+#define B_EFI_PLATFORM_INFO_RATIO_LIMIT (1 << 28)
+#define B_EFI_PLATFORM_INFO_SMM_SAVE_CONTROL (1 << 16)
+#define N_EFI_PLATFORM_INFO_PROG_TCC_ACTIVATION_OFFSET 30
+#define B_EFI_PLATFORM_INFO_PROG_TCC_ACTIVATION_OFFSET (1 << 30)
 
 // #define PLATFORM_INFO_SET_TDP
 
-#define MSR_PMG_IO_CAPTURE_BASE  0xE4
-#define MSR_IA32_EXT_CONFIG      0xEE
-#define MSR_FEATURE_CONFIG       0x13C
-#define MSR_FLEX_RATIO           0x194
-#define FLEX_RATIO_LOCK          (1U << 20U)
-#define FLEX_RATIO_EN            (1U << 16U)
-#define MSR_IA32_PERF_CONTROL    0x199
-#define MSR_THERM2_CTL           0x19D
+#define MSR_PMG_IO_CAPTURE_BASE 0xE4
+#define MSR_IA32_EXT_CONFIG 0xEE
+#define MSR_FEATURE_CONFIG 0x13C
+#define MSR_FLEX_RATIO 0x194
+#define FLEX_RATIO_LOCK (1U << 20U)
+#define FLEX_RATIO_EN (1U << 16U)
+#define MSR_IA32_PERF_CONTROL 0x199
+#define MSR_THERM2_CTL 0x19D
 
-#define TURBO_DISABLE_MASK      ((UINT64)1 << 38)
-#define TURBO_MODE_DISABLE_BIT  38
+#define TURBO_DISABLE_MASK ((UINT64)1 << 38)
+#define TURBO_MODE_DISABLE_BIT 38
 
-#define MSR_TEMPERATURE_TARGET            0x1A2
-#define MSR_MISC_PWR_MGMT                 0x1AA
-#define MISC_PWR_MGMT_EIST_HW_DIS         (1 << 0)
-#define MISC_PWR_MGMT_LOCK                (1 << 13)
-#define MAX_RATIO_LIMIT_8C_OFFSET         56
-#define MAX_RATIO_LIMIT_7C_OFFSET         48
-#define MAX_RATIO_LIMIT_6C_OFFSET         40
-#define MAX_RATIO_LIMIT_5C_OFFSET         32
-#define MAX_RATIO_LIMIT_4C_OFFSET         24
-#define MAX_RATIO_LIMIT_3C_OFFSET         16
-#define MAX_RATIO_LIMIT_2C_OFFSET         8
-#define MAX_RATIO_LIMIT_1C_OFFSET         0
-#define MAX_RATIO_LIMIT_MASK              0xff
-#define MSR_IA32_ENERGY_PERFORMANCE_BIAS  0x1B0
-#define ENERGY_POLICY_PERFORMANCE         0
-#define ENERGY_POLICY_NORMAL              6
-#define ENERGY_POLICY_POWERSAVE           15
-#define MSR_POWER_CTL                     0x1FC
-#define MSR_LT_LOCK_MEMORY                0x2E7
-#define MSR_IA32_CR_PAT                   0x277
+#define MSR_TEMPERATURE_TARGET 0x1A2
+#define MSR_MISC_PWR_MGMT 0x1AA
+#define MISC_PWR_MGMT_EIST_HW_DIS (1 << 0)
+#define MISC_PWR_MGMT_LOCK (1 << 13)
+#define MAX_RATIO_LIMIT_8C_OFFSET 56
+#define MAX_RATIO_LIMIT_7C_OFFSET 48
+#define MAX_RATIO_LIMIT_6C_OFFSET 40
+#define MAX_RATIO_LIMIT_5C_OFFSET 32
+#define MAX_RATIO_LIMIT_4C_OFFSET 24
+#define MAX_RATIO_LIMIT_3C_OFFSET 16
+#define MAX_RATIO_LIMIT_2C_OFFSET 8
+#define MAX_RATIO_LIMIT_1C_OFFSET 0
+#define MAX_RATIO_LIMIT_MASK 0xff
+#define MSR_IA32_ENERGY_PERFORMANCE_BIAS 0x1B0
+#define ENERGY_POLICY_PERFORMANCE 0
+#define ENERGY_POLICY_NORMAL 6
+#define ENERGY_POLICY_POWERSAVE 15
+#define MSR_POWER_CTL 0x1FC
+#define MSR_LT_LOCK_MEMORY 0x2E7
+#define MSR_IA32_CR_PAT 0x277
 
 // Sandy Bridge & JakeTown specific 'Running Average Power Limit' MSR's.
-#define MSR_PP0_CURRENT_CONFIG  0x601
-#define PP0_CURRENT_LIMIT       (112 << 3)           ///< 112 A
-#define MSR_PP1_CURRENT_CONFIG  0x602
-#define PP1_CURRENT_LIMIT       (35 << 3)            ///< 35 A
-#define MSR_PKG_POWER_SKU_UNIT  0x606
+#define MSR_PP0_CURRENT_CONFIG 0x601
+#define PP0_CURRENT_LIMIT (112 << 3) ///< 112 A
+#define MSR_PP1_CURRENT_CONFIG 0x602
+#define PP1_CURRENT_LIMIT (35 << 3) ///< 35 A
+#define MSR_PKG_POWER_SKU_UNIT 0x606
 
-#define MSR_PKGC3_IRTL      0x60A
-#define MSR_PKGC6_IRTL      0x60B
-#define MSR_PKGC7_IRTL      0x60C
-#define IRTL_VALID          (1 << 15)
-#define IRTL_1_NS           (0 << 10)
-#define IRTL_32_NS          (1 << 10)
-#define IRTL_1024_NS        (2 << 10)
-#define IRTL_32768_NS       (3 << 10)
-#define IRTL_1048576_NS     (4 << 10)
-#define IRTL_33554432_NS    (5 << 10)
-#define IRTL_RESPONSE_MASK  (0x3ff)
+#define MSR_PKGC3_IRTL 0x60A
+#define MSR_PKGC6_IRTL 0x60B
+#define MSR_PKGC7_IRTL 0x60C
+#define IRTL_VALID (1 << 15)
+#define IRTL_1_NS (0 << 10)
+#define IRTL_32_NS (1 << 10)
+#define IRTL_1024_NS (2 << 10)
+#define IRTL_32768_NS (3 << 10)
+#define IRTL_1048576_NS (4 << 10)
+#define IRTL_33554432_NS (5 << 10)
+#define IRTL_RESPONSE_MASK (0x3ff)
 
 // long duration in low dword, short duration in high dword
-#define MSR_PKG_POWER_LIMIT         0x610
-#define PKG_POWER_LIMIT_MASK        0x7fff
-#define PKG_POWER_LIMIT_EN          (1 << 15)
-#define PKG_POWER_LIMIT_CLAMP       (1 << 16)
-#define PKG_POWER_LIMIT_TIME_SHIFT  17
-#define PKG_POWER_LIMIT_TIME_MASK   0x7f
+#define MSR_PKG_POWER_LIMIT 0x610
+#define PKG_POWER_LIMIT_MASK 0x7fff
+#define PKG_POWER_LIMIT_EN (1 << 15)
+#define PKG_POWER_LIMIT_CLAMP (1 << 16)
+#define PKG_POWER_LIMIT_TIME_SHIFT 17
+#define PKG_POWER_LIMIT_TIME_MASK 0x7f
 
-#define MSR_PKG_ENERGY_STATUS  0x611
-#define MSR_PKG_PERF_STATUS    0x613
-#define MSR_PKG_POWER_SKU      0x614
+#define MSR_PKG_ENERGY_STATUS 0x611
+#define MSR_PKG_PERF_STATUS 0x613
+#define MSR_PKG_POWER_SKU 0x614
 
 // Sandy Bridge IA (Core) domain MSR's.
-#define MSR_PP0_POWER_LIMIT    0x638
-#define MSR_PP0_ENERGY_STATUS  0x639
-#define MSR_PP0_POLICY         0x63A
-#define MSR_PP0_PERF_STATUS    0x63B
+#define MSR_PP0_POWER_LIMIT 0x638
+#define MSR_PP0_ENERGY_STATUS 0x639
+#define MSR_PP0_POLICY 0x63A
+#define MSR_PP0_PERF_STATUS 0x63B
 
 // Sandy Bridge Uncore (IGPU) domain MSR's (Not on JakeTown).
-#define MSR_PP1_POWER_LIMIT    0x640
-#define MSR_PP1_ENERGY_STATUS  0x641
-#define MSR_PP1_POLICY         0x642
+#define MSR_PP1_POWER_LIMIT 0x640
+#define MSR_PP1_ENERGY_STATUS 0x641
+#define MSR_PP1_POLICY 0x642
 
 // JakeTown only Memory MSR's.
-#define MSR_DRAM_POWER_LIMIT    0x618
-#define MSR_DRAM_ENERGY_STATUS  0x619
-#define MSR_DRAM_PERF_STATUS    0x61B
-#define MSR_DRAM_POWER_INFO     0x61C
+#define MSR_DRAM_POWER_LIMIT 0x618
+#define MSR_DRAM_ENERGY_STATUS 0x619
+#define MSR_DRAM_PERF_STATUS 0x61B
+#define MSR_DRAM_POWER_INFO 0x61C
 
 //
 // Page Attribute Table (PAT) cache types.
-// Note that the final memory cache type is defined according to the combination (ref. 11.5.2.2) of
-// PAT (ref. 11.12) and MTRR (ref. 11.11) and cannot be derived from either separately.
-// REF: Intel® 64 and IA-32 Architectures Software Developer’s Manual - Volume 3A: System Programming Guide, Part 1
+// Note that the final memory cache type is defined according to the combination
+// (ref. 11.5.2.2) of PAT (ref. 11.12) and MTRR (ref. 11.11) and cannot be
+// derived from either separately. REF: Intel® 64 and IA-32 Architectures
+// Software Developer’s Manual - Volume 3A: System Programming Guide, Part 1
 //
 typedef enum {
-  PatUncacheable    = 0,
-  PatWriteCombining = 1, ///< Special hardware burst mode (not L1-L3) intended for graphics memory (ref. 11.3.1).
-  PatWriteThrough   = 4,
+  PatUncacheable = 0,
+  PatWriteCombining = 1, ///< Special hardware burst mode (not L1-L3) intended
+                         ///< for graphics memory (ref. 11.3.1).
+  PatWriteThrough = 4,
   PatWriteProtected = 5,
-  PatWriteBack      = 6,
-  PatUncached       = 7
+  PatWriteBack = 6,
+  PatUncached = 7
 } PAT_MEMORY_CACHE_TYPE;
 
 //
 // Mask for one PAT entry in MSR.
 //
-#define PAT_ENTRY_BIT_MASK  (0xFFU)
+#define PAT_ENTRY_BIT_MASK (0xFFU)
 
 //
 // Number of PAT entries in MSR.
 //
-#define PAT_INDEX_MAX  8
+#define PAT_INDEX_MAX 8
 
 //
 // Specify PAT type at index in PAT MSR.
 //
-#define SET_PAT_N(PatIndex, PatType)  (LShiftU64 ((PatType) * 1ULL, (PatIndex) * 8))
+#define SET_PAT_N(PatIndex, PatType)                                           \
+  (LShiftU64((PatType) * 1ULL, (PatIndex) * 8))
 
 //
 // Get PAT type at index in PAT MSR.
 //
-#define GET_PAT_N(PatMsr, PatIndex)  (RShiftU64 ((PatMsr), (PatIndex) * 8) & PAT_ENTRY_BIT_MASK)
+#define GET_PAT_N(PatMsr, PatIndex)                                            \
+  (RShiftU64((PatMsr), (PatIndex) * 8) & PAT_ENTRY_BIT_MASK)
 
 //
 // Modify PAT type at index in PAT MSR.
 //
-#define MODIFY_PAT_MSR(PatMsr, PatIndex, PatType)  (((PatMsr) & ~SET_PAT_N ((PatIndex), PAT_ENTRY_BIT_MASK)) | SET_PAT_N ((PatIndex), (PatType)))
+#define MODIFY_PAT_MSR(PatMsr, PatIndex, PatType)                              \
+  (((PatMsr) & ~SET_PAT_N((PatIndex), PAT_ENTRY_BIT_MASK)) |                   \
+   SET_PAT_N((PatIndex), (PatType)))
 
 //
 // Intel defined power-on default contents of MSR_IA32_CR_PAT.
 //
-#define PAT_DEFAULTS  (             \
-  SET_PAT_N (0, PatWriteBack)     | \
-  SET_PAT_N (1, PatWriteThrough)  | \
-  SET_PAT_N (2, PatUncached)      | \
-  SET_PAT_N (3, PatUncacheable)   | \
-  SET_PAT_N (4, PatWriteBack)     | \
-  SET_PAT_N (5, PatWriteThrough)  | \
-  SET_PAT_N (6, PatUncached)      | \
-  SET_PAT_N (7, PatUncacheable)     \
-)
+#define PAT_DEFAULTS                                                           \
+  (SET_PAT_N(0, PatWriteBack) | SET_PAT_N(1, PatWriteThrough) |                \
+   SET_PAT_N(2, PatUncached) | SET_PAT_N(3, PatUncacheable) |                  \
+   SET_PAT_N(4, PatWriteBack) | SET_PAT_N(5, PatWriteThrough) |                \
+   SET_PAT_N(6, PatUncached) | SET_PAT_N(7, PatUncacheable))
 
-#define K8_FIDVID_STATUS   0xC0010042
-#define K10_COFVID_STATUS  0xC0010071
-#define K10_PSTATE_STATUS  0xC0010064
+#define K8_FIDVID_STATUS 0xC0010042
+#define K10_COFVID_STATUS 0xC0010071
+#define K10_PSTATE_STATUS 0xC0010064
 
-#define CPU_MODEL_WILLAMETTE      0x01 ///< Willamette, Foster
-#define CPU_MODEL_NORTHWOOD       0x02 ///< Northwood, Prestonia, Gallatin
-#define CPU_MODEL_PRESCOTT        0x03 ///< Prescott, Nocona, Cranford, Potomac
-#define CPU_MODEL_PRESCOTT_2M     0x04 ///< Prescott 2M, Smithfield, Irwindale, Paxville
-#define CPU_MODEL_CEDAR_MILL      0x06 ///< Cedar Mill, Presler, Tusla, Dempsey
-#define CPU_MODEL_BANIAS          0x09 ///< Banias
-#define CPU_MODEL_DOTHAN          0x0D ///< Dothan
-#define CPU_MODEL_YONAH           0x0E ///< Sossaman, Yonah
-#define CPU_MODEL_MEROM           0x0F ///< Allendale, Conroe, Kentsfield, Woodcrest, Clovertown, Tigerton, Merom
-#define CPU_MODEL_PENRYN          0x17 ///< Wolfdale, Yorkfield, Harpertown, Penryn
-#define CPU_MODEL_NEHALEM         0x1A ///< Bloomfield, Nehalem-EP, Nehalem-WS, Gainestown
-#define CPU_MODEL_BONNELL         0x1C ///< Bonnell, Silverthorne, Diamondville, Pineview
-#define CPU_MODEL_FIELDS          0x1E ///< Lynnfield, Clarksfield, Jasper Forest
-#define CPU_MODEL_DALES           0x1F ///< Havendale, Auburndale
-#define CPU_MODEL_NEHALEM_EX      0x2E ///< Beckton
-#define CPU_MODEL_DALES_32NM      0x25 ///< Clarkdale, Arrandale
-#define CPU_MODEL_BONNELL_MID     0x26 ///< Bonnell, Lincroft
-#define CPU_MODEL_WESTMERE        0x2C ///< Gulftown, Westmere-EP, Westmere-WS
-#define CPU_MODEL_WESTMERE_EX     0x2F
-#define CPU_MODEL_SANDYBRIDGE     0x2A ///< Sandy Bridge
-#define CPU_MODEL_JAKETOWN        0x2D ///< Sandy Bridge Xeon E5, Core i7 Extreme
-#define CPU_MODEL_SALTWELL        0x36 ///< Saltwell, Cedarview
-#define CPU_MODEL_SILVERMONT      0x37 ///< Bay Trail
-#define CPU_MODEL_IVYBRIDGE       0x3A ///< Ivy Bridge
-#define CPU_MODEL_IVYBRIDGE_EP    0x3E
-#define CPU_MODEL_CRYSTALWELL     0x46
-#define CPU_MODEL_HASWELL         0x3C
-#define CPU_MODEL_HASWELL_EP      0x3F ///< Haswell MB
-#define CPU_MODEL_HASWELL_ULT     0x45 ///< Haswell ULT
-#define CPU_MODEL_BROADWELL       0x3D ///< Broadwell
-#define CPU_MODEL_BROADWELL_EP    0x4F ///< Broadwell_EP
-#define CPU_MODEL_BROADWELL_ULX   0x3D
-#define CPU_MODEL_BROADWELL_ULT   0x3D
-#define CPU_MODEL_BRYSTALWELL     0x47
-#define CPU_MODEL_AIRMONT         0x4C ///< CherryTrail / Braswell
-#define CPU_MODEL_AVOTON          0x4D ///< Avaton/Rangely
-#define CPU_MODEL_SKYLAKE         0x4E ///< Skylake-S
-#define CPU_MODEL_SKYLAKE_ULT     0x4E
-#define CPU_MODEL_SKYLAKE_ULX     0x4E
-#define CPU_MODEL_SKYLAKE_DT      0x5E
-#define CPU_MODEL_SKYLAKE_W       0x55
-#define CPU_MODEL_GOLDMONT        0x5C ///< Apollo Lake
-#define CPU_MODEL_DENVERTON       0x5F ///< Goldmont Microserver
-#define CPU_MODEL_CANNONLAKE      0x66
-#define CPU_MODEL_XEON_MILL       0x85 ///< Knights Mill
-#define CPU_MODEL_KABYLAKE        0x8E ///< Kabylake Dektop
-#define CPU_MODEL_KABYLAKE_ULT    0x8E
-#define CPU_MODEL_KABYLAKE_ULX    0x8E
-#define CPU_MODEL_KABYLAKE_DT     0x9E
-#define CPU_MODEL_COFFEELAKE      0x9E
-#define CPU_MODEL_COFFEELAKE_ULT  0x9E
-#define CPU_MODEL_COFFEELAKE_ULX  0x9E
-#define CPU_MODEL_COFFEELAKE_DT   0x9E
-#define CPU_MODEL_ICELAKE_Y       0x7D
-#define CPU_MODEL_ICELAKE_U       0x7E
-#define CPU_MODEL_ICELAKE_SP      0x9F /* Some variation of Ice Lake */
-#define CPU_MODEL_COMETLAKE_S     0xA5 /* desktop CometLake */
-#define CPU_MODEL_COMETLAKE_Y     0xA5 /* aka 10th generation Amber Lake Y */
-#define CPU_MODEL_COMETLAKE_U     0xA6
-#define CPU_MODEL_ROCKETLAKE_S    0xA7/* 11h desktop RocketLake */
-#define CPU_MODEL_TIGERLAKE_U     0x8C
-#define CPU_MODEL_ALDERLAKE_S     0x97
-//from Clover
-#define CPU_MODEL_ALDERLAKE_ULT   0x9A  /* 12h generation Alder Lake, i5-12500h */
-#define CPU_MODEL_RAPTORLAKE      0xB7  /* 13h Raptor Lake */
-#define CPU_MODEL_RAPTORLAKE_B    0xBF  /* 13h Raptor Lake, i5-13400h */
-#define CPU_MODEL_METEORLAKE      0xAA  /* 14h Meteor Lake */
-#define CPU_MODEL_ARROWLAKE		  0xC6
-#define CPU_MODEL_ARROWLAKE_X	  0xC5  /* 15h Arrow Lake */
-#define CPU_MODEL_ARROWLAKE_U	  0xB5  /* 15h Arrow Lake */
+#define CPU_MODEL_WILLAMETTE 0x01 ///< Willamette, Foster
+#define CPU_MODEL_NORTHWOOD 0x02  ///< Northwood, Prestonia, Gallatin
+#define CPU_MODEL_PRESCOTT 0x03   ///< Prescott, Nocona, Cranford, Potomac
+#define CPU_MODEL_PRESCOTT_2M                                                  \
+  0x04 ///< Prescott 2M, Smithfield, Irwindale, Paxville
+#define CPU_MODEL_CEDAR_MILL 0x06 ///< Cedar Mill, Presler, Tusla, Dempsey
+#define CPU_MODEL_BANIAS 0x09     ///< Banias
+#define CPU_MODEL_DOTHAN 0x0D     ///< Dothan
+#define CPU_MODEL_YONAH 0x0E      ///< Sossaman, Yonah
+#define CPU_MODEL_MEROM                                                        \
+  0x0F ///< Allendale, Conroe, Kentsfield, Woodcrest, Clovertown, Tigerton,
+       ///< Merom
+#define CPU_MODEL_PENRYN 0x17 ///< Wolfdale, Yorkfield, Harpertown, Penryn
+#define CPU_MODEL_NEHALEM                                                      \
+  0x1A ///< Bloomfield, Nehalem-EP, Nehalem-WS, Gainestown
+#define CPU_MODEL_BONNELL                                                      \
+  0x1C                        ///< Bonnell, Silverthorne, Diamondville, Pineview
+#define CPU_MODEL_FIELDS 0x1E ///< Lynnfield, Clarksfield, Jasper Forest
+#define CPU_MODEL_DALES 0x1F  ///< Havendale, Auburndale
+#define CPU_MODEL_NEHALEM_EX 0x2E  ///< Beckton
+#define CPU_MODEL_DALES_32NM 0x25  ///< Clarkdale, Arrandale
+#define CPU_MODEL_BONNELL_MID 0x26 ///< Bonnell, Lincroft
+#define CPU_MODEL_WESTMERE 0x2C    ///< Gulftown, Westmere-EP, Westmere-WS
+#define CPU_MODEL_WESTMERE_EX 0x2F
+#define CPU_MODEL_SANDYBRIDGE 0x2A ///< Sandy Bridge
+#define CPU_MODEL_JAKETOWN 0x2D    ///< Sandy Bridge Xeon E5, Core i7 Extreme
+#define CPU_MODEL_SALTWELL 0x36    ///< Saltwell, Cedarview
+#define CPU_MODEL_SILVERMONT 0x37  ///< Bay Trail
+#define CPU_MODEL_IVYBRIDGE 0x3A   ///< Ivy Bridge
+#define CPU_MODEL_IVYBRIDGE_EP 0x3E
+#define CPU_MODEL_CRYSTALWELL 0x46
+#define CPU_MODEL_HASWELL 0x3C
+#define CPU_MODEL_HASWELL_EP 0x3F   ///< Haswell MB
+#define CPU_MODEL_HASWELL_ULT 0x45  ///< Haswell ULT
+#define CPU_MODEL_BROADWELL 0x3D    ///< Broadwell
+#define CPU_MODEL_BROADWELL_EP 0x4F ///< Broadwell_EP
+#define CPU_MODEL_BROADWELL_ULX 0x3D
+#define CPU_MODEL_BROADWELL_ULT 0x3D
+#define CPU_MODEL_BRYSTALWELL 0x47
+#define CPU_MODEL_AIRMONT 0x4C ///< CherryTrail / Braswell
+#define CPU_MODEL_AVOTON 0x4D  ///< Avaton/Rangely
+#define CPU_MODEL_SKYLAKE 0x4E ///< Skylake-S
+#define CPU_MODEL_SKYLAKE_ULT 0x4E
+#define CPU_MODEL_SKYLAKE_ULX 0x4E
+#define CPU_MODEL_SKYLAKE_DT 0x5E
+#define CPU_MODEL_SKYLAKE_W 0x55
+#define CPU_MODEL_GOLDMONT 0x5C  ///< Apollo Lake
+#define CPU_MODEL_DENVERTON 0x5F ///< Goldmont Microserver
+#define CPU_MODEL_CANNONLAKE 0x66
+#define CPU_MODEL_XEON_MILL 0x85 ///< Knights Mill
+#define CPU_MODEL_KABYLAKE 0x8E  ///< Kabylake Dektop
+#define CPU_MODEL_KABYLAKE_ULT 0x8E
+#define CPU_MODEL_KABYLAKE_ULX 0x8E
+#define CPU_MODEL_KABYLAKE_DT 0x9E
+#define CPU_MODEL_COFFEELAKE 0x9E
+#define CPU_MODEL_COFFEELAKE_ULT 0x9E
+#define CPU_MODEL_COFFEELAKE_ULX 0x9E
+#define CPU_MODEL_COFFEELAKE_DT 0x9E
+#define CPU_MODEL_ICELAKE_Y 0x7D
+#define CPU_MODEL_ICELAKE_U 0x7E
+#define CPU_MODEL_ICELAKE_SP 0x9F  /* Some variation of Ice Lake */
+#define CPU_MODEL_COMETLAKE_S 0xA5 /* desktop CometLake */
+#define CPU_MODEL_COMETLAKE_Y 0xA5 /* aka 10th generation Amber Lake Y */
+#define CPU_MODEL_COMETLAKE_U 0xA6
+#define CPU_MODEL_ROCKETLAKE_S 0xA7 /* 11h desktop RocketLake */
+#define CPU_MODEL_TIGERLAKE_U 0x8C
+#define CPU_MODEL_ALDERLAKE_S 0x97
+// from Clover
+#define CPU_MODEL_ALDERLAKE_ULT 0x9A /* 12h generation Alder Lake, i5-12500h   \
+                                      */
+#define CPU_MODEL_RAPTORLAKE 0xB7    /* 13h Raptor Lake */
+#define CPU_MODEL_RAPTORLAKE_B 0xBF  /* 13h Raptor Lake, i5-13400h */
+#define CPU_MODEL_METEORLAKE 0xAA    /* 14h Meteor Lake */
+#define CPU_MODEL_ARROWLAKE 0xC6
+#define CPU_MODEL_ARROWLAKE_X 0xC5 /* 15h Arrow Lake */
+#define CPU_MODEL_ARROWLAKE_U 0xB5 /* 15h Arrow Lake */
 
-
-#define AMD_CPU_FAMILY          0xF
-#define AMD_CPU_EXT_FAMILY_0FH  0x0
-#define AMD_CPU_EXT_FAMILY_10H  0x1
-#define AMD_CPU_EXT_FAMILY_15H  0x6
-#define AMD_CPU_EXT_FAMILY_16H  0x7
-#define AMD_CPU_EXT_FAMILY_17H  0x8
-#define AMD_CPU_EXT_FAMILY_19H  0xA
+#define AMD_CPU_FAMILY 0xF
+#define AMD_CPU_EXT_FAMILY_0FH 0x0
+#define AMD_CPU_EXT_FAMILY_10H 0x1
+#define AMD_CPU_EXT_FAMILY_15H 0x6
+#define AMD_CPU_EXT_FAMILY_16H 0x7
+#define AMD_CPU_EXT_FAMILY_17H 0x8
+#define AMD_CPU_EXT_FAMILY_19H 0xA
+#define AMD_CPU_EXT_FAMILY_1AH 0xB
 
 // CPU_P_STATE_COORDINATION
 /// P-State Coordination
 typedef enum {
-  /// The OS Power Manager is responsible for coordinating the P-state among logical
-  /// processors with dependencies and must initiate the transition on all of those Logical Processors.
+  /// The OS Power Manager is responsible for coordinating the P-state among
+  /// logical
+  /// processors with dependencies and must initiate the transition on all of
+  /// those Logical Processors.
   CpuPStateCoordinationSoftwareAll = 0xFC,
 
-  /// The OS Power Manager is responsible for coordinating the P-state among logical
-  /// processors with dependencies and may initiate the transition on any of those Logical Processors.
+  /// The OS Power Manager is responsible for coordinating the P-state among
+  /// logical
+  /// processors with dependencies and may initiate the transition on any of
+  /// those Logical Processors.
   CpuPStateCoordinationSoftwareAny = 0xFD,
 
-  /// The processor hardware is responsible for coordinating the P-state among logical
-  /// processors dependencies. The OS is responsible for keeping the P-state request up to date on all
+  /// The processor hardware is responsible for coordinating the P-state among
+  /// logical
+  /// processors dependencies. The OS is responsible for keeping the P-state
+  /// request up to date on all
   /// logical processors.
   CpuPStateCoordinationHardwareAll = 0xFE
 } CPU_P_STATE_COORDINATION;


### PR DESCRIPTION
This PR selectively imports newer definitions from Acidanthera upstream to support modern hardware, while preserving Clover's specific patches (like XhciPortLimit for Tahoe).

**Changes:**
1. **ProcessorInfo.h:** Added missing AMD CPU families (Zen 4/5, including 1Ah).
2. **OcConfigurationLib.h:** Imported definitions for `ClearTaskSwitchBit` quirk and `Unload` driver array.

This enables Clover to recognize newer CPUs and prepares the codebase for future feature implementations without breaking existing Tahoe compatibility.